### PR TITLE
Minhash densification with empty sketches, SIMD-accelerated PCSA patch, and fast{mod/div} in Python

### DIFF
--- a/include/sketch/bbmh.h
+++ b/include/sketch/bbmh.h
@@ -61,8 +61,8 @@ static inline double harmonic_cardinality_estimate_diffmax_impl(const Cont &minv
 
 template<typename Cont>
 static inline double harmonic_cardinality_estimate_impl(const Cont &minvec) {
-    using VT = typename Cont::value_type;
-    if(std::find(minvec.begin(), minvec.end(), detail::default_val<VT>() != minvec.end())) {
+    using VT = std::decay_t<decltype(*minvec.begin())>;
+    if(std::find(minvec.begin(), minvec.end(), detail::default_val<VT>()) != minvec.end()) {
         if(!std::all_of(minvec.begin(), minvec.end(), [](auto x) {return x == detail::default_val<VT>();}))
             throw std::runtime_error("Should have been densified");
     }

--- a/include/sketch/bbmh.h
+++ b/include/sketch/bbmh.h
@@ -40,6 +40,7 @@ inline int densifybin(Container &hashes) {
         return 0; // Full sketch
     }
     if (min == empty_val) {
+        std::fill(hashes.begin(), hashes.end(), empty_val);
         return -1; // Empty sketch
     }
     for (uint64_t i = 0; i < hashes.size(); i++) {
@@ -748,7 +749,7 @@ public:
         }
 #endif
         assert(core_.size() % 64 == 0);
-        if(b_ < 1 || b_ > 64) throw "a party";
+        if(b_ < 1 || b_ > 64) throw std::invalid_argument("b must be >= 1 and <= 64");
     }
     bool operator==(const DivBBitMinHasher &o) const {
         return b_ == o.b_ && std::equal(core_.begin(), core_.end(), o.core_.begin());
@@ -1556,9 +1557,8 @@ FinalBBitMinHash BBitMinHasher<T, Hasher>::finalize(uint32_t b) const {
         std::replace(tmp.begin(), tmp.end(), std::numeric_limits<T>::max() >> p_, detail::default_val<T>());
         int ret = detail::densifybin(tmp);
         if(ret < 0) {
-            throw std::runtime_error("Could not densify empty sketch");
+            std::cerr << "Could not densify empty sketch; setting all minimizers to empty value. It will compare completely equal to all empty sketches and full dissimilar to all others.\n";
         }
-        //if(ret) throw std::runtime_error((std::string("Error code ") + std::to_string(ret)).data());
         assert(std::find(tmp.begin(), tmp.end(), detail::default_val<T>()) == tmp.end());
         ptr = &tmp;
     }

--- a/include/sketch/bbmh.h
+++ b/include/sketch/bbmh.h
@@ -1557,7 +1557,7 @@ FinalBBitMinHash BBitMinHasher<T, Hasher>::finalize(uint32_t b) const {
         std::replace(tmp.begin(), tmp.end(), std::numeric_limits<T>::max() >> p_, detail::default_val<T>());
         int ret = detail::densifybin(tmp);
         if(ret < 0) {
-            std::cerr << "Could not densify empty sketch; setting all minimizers to empty value. It will compare completely equal to all empty sketches and full dissimilar to all others.\n";
+            std::fprintf(stderr, "Could not densify empty sketch; setting all minimizers to empty value. It will compare completely equal to all empty sketches and full dissimilar to all others.\n");
         }
         assert(std::find(tmp.begin(), tmp.end(), detail::default_val<T>()) == tmp.end());
         ptr = &tmp;

--- a/include/sketch/bbmh.h
+++ b/include/sketch/bbmh.h
@@ -62,6 +62,10 @@ static inline double harmonic_cardinality_estimate_diffmax_impl(const Cont &minv
 template<typename Cont>
 static inline double harmonic_cardinality_estimate_impl(const Cont &minvec) {
     using VT = typename Cont::value_type;
+    if(std::find(minvec.begin(), minvec.end(), detail::default_val<VT>() != minvec.end())) {
+        if(!std::all_of(minvec.begin(), minvec.end(), [](auto x) {return x == detail::default_val<VT>();}))
+            throw std::runtime_error("Should have been densified");
+    }
     assert(std::find(minvec.begin(), minvec.end(), detail::default_val<VT>()) == minvec.end());
     const long double num = is_pow2(minvec.size()) ? std::ldexp(static_cast<long double>(1.), sizeof(VT) * CHAR_BIT - ilog2(minvec.size()))
                                               : ((long double)UINT64_C(-1)) / minvec.size();
@@ -1559,12 +1563,10 @@ FinalBBitMinHash BBitMinHasher<T, Hasher>::finalize(uint32_t b) const {
         if(ret < 0) {
             std::fprintf(stderr, "Could not densify empty sketch; setting all minimizers to empty value. It will compare completely equal to all empty sketches and full dissimilar to all others.\n");
         }
-        assert(std::find(tmp.begin(), tmp.end(), detail::default_val<T>()) == tmp.end());
         ptr = &tmp;
     }
     const auto &core_ref = *ptr;
     if(cest < 0) cest = detail::harmonic_cardinality_estimate_impl(core_ref);
-    assert(std::find(core_ref.begin(), core_ref.end(), detail::default_val<T>()) == core_ref.end());
     using detail::getnthbit;
     using detail::setnthbit;
     FinalBBitMinHash ret(p_, b, cest);

--- a/include/sketch/hash.h
+++ b/include/sketch/hash.h
@@ -257,13 +257,10 @@ inline uint64_t CWtrick64(uint64_t x, const std::array<int96_t, k> &keys) {
 }
 
 namespace nosiam {
+
 INLINE __uint128_t mod127(__uint128_t x) {
     static constexpr __uint128_t mod = (__uint128_t(1) << 127) - 1;
     x = (x >> 127) + (x & mod);
-    if(HEDLEY_UNLIKELY(x == __uint128_t(-1))) {
-        return mod + 3;
-        // = (x >> 127) + (x & mod);
-    }
     if(x > mod) x -= mod;
     return x;
 }

--- a/include/sketch/mh.h
+++ b/include/sketch/mh.h
@@ -466,6 +466,10 @@ class CountingRangeMinHash: public AbstractMinHash<T, Cmp> {
         }
         VType(T v, CountType c): first(v), second(c) {}
         VType(const VType &o): first(o.first), second(o.second) {}
+        VType &operator=(const VType &o) {
+            this->first = o.first;
+            this->second = o.second;
+        }
         VType(gzFile fp) {if(gzread(fp, this, sizeof(*this)) != sizeof(*this)) throw ZlibError("Failed to read");}
     };
     Hasher hf_;

--- a/include/sketch/pc.h
+++ b/include/sketch/pc.h
@@ -41,14 +41,22 @@ public:
     T getregister() const {return sketch_;}
 };
 
-template<typename T>
+template<typename T, typename=std::enable_if_t<std::is_integral<T>::value>>
 class PCSA {
+    /*
+     * Note: See https://arxiv.org/abs/2007.08051
+             for recent theory on space/accuracy results.
+     */
     std::unique_ptr<T[]> counters_;
     const size_t n_;
 public:
     PCSA(size_t n): counters_(new T[n]), n_(n) {
         std::memset(counters_.get(), 0, sizeof(T) * n_);
     }
+    PCSA(const PCSA &o): counters_(new T[o.n_]), n_(o.n_) {
+        std::memcpy(counters_.get(), o.counters_.get(), sizeof(T) * n_);
+    }
+    PCSA(PCSA &&o) = default;
     PCSA &operator|=(const PCSA &o) {
         for(unsigned i = 0; i < n_; ++i) counters_[i] |= o.counters_[i];
         return *this;
@@ -62,10 +70,46 @@ public:
         counters_[ind] |= detail::R(value);
     }
     double report() const {
-        auto mean = 
+        double mean = 
             double(std::accumulate(counters_.get(), counters_.get() + n_, 0u, [](auto x, auto y) {
                 return detail::r(y) + x;
             })) / n_;
+        CONST_IF(sizeof(T) == 4) {
+#if __AVX2__
+            __m256 sums = _mm256_setzero_ps();
+            static constexpr size_t nper = sizeof(__m256i) / 4;
+            const size_t nsimd = n_ / nper;
+            size_t i;
+            for(i = 0; i < nsimd; ++i) {
+                __m256i vals = _mm256_loadu_si256((const __m256i *)&counters_[i * nper]);
+                // x = R(x) - 1 = (~x & (x + 1))
+                __m256i vx = _mm256_andnot_si256(vals, _mm256_add_epi32(vals, _mm256_set1_epi32(1)));
+                // x = popcount(x)
+                auto start = (uint32_t *)&vx;
+                SK_UNROLL_8
+                for(unsigned i = 0; i < nper; ++i) {
+                    start[i] = popcount(start[i]);
+                }
+                // x = vector of floats via popcount(x)
+                // Acccumulate
+                sums = _mm256_add_ps(sums, _mm256_cvtepi32_ps(vx));
+            }
+            // Reduce
+            double sum = 0.;
+            for(unsigned i = 0; i < nper; ++i) sum += ((float *)&sums)[i];
+            for(i *= nper; i < n_; ++i) {
+                sum += detail::r(counters_[i]);
+            }
+            sum /= n_;
+            return n_ * 1.292808 * sum * sum;
+#endif
+        }
+        /* Notes: this could be accelerated
+           1. Apply R(x) - 1 using SIMD
+           2. Apply popcount using SIMD
+           3. convert to floats
+           4. Accumulate into a result
+        */
         return n_ * 1.292808 * std::pow(2, mean);
     }
 };


### PR DESCRIPTION
This addresses https://github.com/dnbaker/dashing/issues/53, accelerated PCSA (a well-compressable composable cardinality estimator), and exposure of fastmod operations (in and out-of-place) for the Python api.

First, by setting all empty sketches to be 'densified' to the empty value at all positions (default status), they compare completely equal to all other empty sketches of the same size, and fully dissimilar to all others.

PCSA has been accelerated for AVX2; there's more room to improve (specifically, using manual popcount methods on the AVX vector rather than calling popcnt on each consitutent).

Fastmod/fastdiv are available as `sketch.fastmod`, `sketch.fastmod_`, `sketch.fastdiv`, and `sketch.fastdiv_`, where the underscore denotes in-place modifications and the standard functions return new numpy arrays of the same type.