### PR TITLE
AVX512F without BW, Expanded BottomKHasher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ FLAGS=-O3 -funroll-loops -pipe -march=native -Iinclude/sketch -I. -Ivec/blaze -I
 
 CXXFLAGS=$(FLAGS) -Wreorder  \
 
+CXXFLAGS+= $(EXTRA)
+
 PYCONF?=python3-config
 
 ifeq ($(shell uname),Darwin)

--- a/include/sketch/bbmh.h
+++ b/include/sketch/bbmh.h
@@ -62,10 +62,8 @@ static inline double harmonic_cardinality_estimate_diffmax_impl(const Cont &minv
 template<typename Cont>
 static inline double harmonic_cardinality_estimate_impl(const Cont &minvec) {
     using VT = std::decay_t<decltype(*minvec.begin())>;
-    if(std::find(minvec.begin(), minvec.end(), detail::default_val<VT>()) != minvec.end()) {
-        if(!std::all_of(minvec.begin(), minvec.end(), [](auto x) {return x == detail::default_val<VT>();}))
-            throw std::runtime_error("Should have been densified");
-    }
+    if(std::all_of(minvec.begin(), minvec.end(), [](auto x) {return x == detail::default_val<VT>();}))
+        return 0.;
     assert(std::find(minvec.begin(), minvec.end(), detail::default_val<VT>()) == minvec.end());
     const long double num = is_pow2(minvec.size()) ? std::ldexp(static_cast<long double>(1.), sizeof(VT) * CHAR_BIT - ilog2(minvec.size()))
                                               : ((long double)UINT64_C(-1)) / minvec.size();
@@ -1556,7 +1554,6 @@ FinalBBitMinHash BBitMinHasher<T, Hasher>::finalize(uint32_t b) const {
         std::fprintf(stderr, "requires densification: %zu/%zu need to be densified\n", ndef, core_.size());
 #endif
         tmp = core_;
-        std::replace(tmp.begin(), tmp.end(), detail::default_val<T>(), std::numeric_limits<T>::max() >> p_);
         cest = detail::harmonic_cardinality_estimate_impl(tmp);
         std::replace(tmp.begin(), tmp.end(), std::numeric_limits<T>::max() >> p_, detail::default_val<T>());
         int ret = detail::densifybin(tmp);

--- a/include/sketch/hll.h
+++ b/include/sketch/hll.h
@@ -1077,17 +1077,16 @@ public:
 #define CR(fp, dst, len) \
     do {\
         if(static_cast<uint64_t>(gzread(fp, dst, len)) != len) {\
-            char buf[512];\
             throw ZlibError(std::string(buf, buf + std::sprintf(buf, "[E:%s:%d:%s] Error reading from file\n", __FILE__, __LINE__, __PRETTY_FUNCTION__))); \
         }\
     } while(0)
+        char buf[512];
         uint32_t bf[4];
         CR(fp, bf, sizeof(bf));
         is_calculated_ = 0;
         estim_  = static_cast<EstimationMethod>(bf[1]);
         jestim_ = static_cast<JointEstimationMethod>(bf[2]);
         CR(fp, &np_, sizeof(np_));
-        std::fprintf(stderr, "read np: %u\n", np_);
         CR(fp, &value_, sizeof(value_));
         core_.resize(m());
         CR(fp, core_.data(), core_.size());

--- a/include/sketch/mh.h
+++ b/include/sketch/mh.h
@@ -76,6 +76,7 @@ public:
 };
 
 template<typename T, typename Allocator> struct FinalRMinHash; // Forward definition
+template<typename HashStruct=WangHash, typename VT=uint64_t, bool select_bottom=true> struct BottomKHasher;
 /*
 The sketch is the set of minimizers.
 
@@ -400,6 +401,8 @@ struct FinalRMinHash {
     FinalRMinHash(std::vector<T, Alloc> &&ofirst): first(std::move(ofirst)) {
         sort();
     }
+    template<typename Hasher, bool is_bottom>
+    FinalRMinHash(const BottomKHasher<Hasher, T, is_bottom> &bk);
     FinalRMinHash(FinalRMinHash &&o): first(std::move(o.first)) {sort();}
     ssize_t read(gzFile fp) {
         uint64_t sz;
@@ -424,10 +427,13 @@ struct FinalRMinHash {
         assert(std::accumulate(first.begin(), first.end(), true, [&](bool t, auto v) {return t && ret >= v;}));
         return ret;
     }
+    template<typename Hasher, bool ismax>
+    FinalRMinHash(BottomKHasher<Hasher, T, ismax> &&prefinal): FinalRMinHash(std::move(prefinal.mpq_.getq())) {
+        prefinal.clear();
+    }
     template<typename Hasher, typename Cmp>
     FinalRMinHash(RangeMinHash<T, Cmp, Hasher> &&prefinal): FinalRMinHash(std::move(prefinal.finalize())) {
         prefinal.clear();
-        sort();
     }
     FinalRMinHash(const std::string &s): FinalRMinHash(s.data()) {}
     FinalRMinHash(gzFile fp) {read(fp);}
@@ -441,6 +447,7 @@ protected:
         common::sort::default_sort(this->first.begin(), this->first.end());
     }
 };
+
 
 template<typename T, typename CountType> struct FinalCRMinHash; // Forward
 
@@ -1146,7 +1153,7 @@ struct SparseShrivastavaHash: public ShrivastavaHash<weighted, Signature, IndexT
         ShrivastavaHash<weighted, Signature, IndexType, FT, true>(std::forward<Args>(args)...) {}
 };
 
-template<typename HashStruct=WangHash, typename VT=uint64_t, bool select_bottom=true>
+template<typename HashStruct, typename VT, bool select_bottom>
 struct BottomKHasher {
     using final_type = FinalRMinHash<VT, Allocator<VT>>;
     using heap_cmp = std::conditional_t<select_bottom,
@@ -1168,6 +1175,14 @@ struct BottomKHasher {
     void clear() {
         set_.clear();
         mpq_.getq().clear();
+    }
+
+    double cardinality_estimate() const {
+        if(select_bottom) {
+            return double(std::numeric_limits<VT>::max()) / this->mpq_.top() * mpq_.size();
+        } else {
+            return double(std::numeric_limits<VT>::max()) / (std::numeric_limits<VT>::max() - this->mpq_.top()) * mpq_.size();
+        }
     }
 
     BottomKHasher(size_t k, HashStruct &&hs=HashStruct()): k_(k), hs_(std::move(hs)) {}

--- a/python/hmh.cpp
+++ b/python/hmh.cpp
@@ -3,8 +3,8 @@
 PYBIND11_MODULE(sketch_hmh, m) {
     m.doc() = "HyperMinHash support";
     py::class_<sketch::HyperMinHash> (m, "hmh")
-        .def(py::init<unsigned, unsigned>())
-        .def(py::init<std::string>())
+        .def(py::init<unsigned, unsigned>(), py::arg("p"), py::arg("rsize") = 8)
+        .def(py::init<std::string>(), py::arg("path"))
         .def("getcard", &sketch::HyperMinHash::getcard, "Emit estimated cardinality. Performs sum if not performed, but sum must be recalculated if further entries are added.")
         .def("add", [](sketch::HyperMinHash &h1, uint64_t v) {h1.add(v);}, "Add a (hashed) value to the sketch.")
         .def("addh", [](sketch::HyperMinHash &h1, py::object p) {
@@ -30,11 +30,6 @@ PYBIND11_MODULE(sketch_hmh, m) {
         }).def("write", [](const sketch::HyperMinHash &h, std::string path) {
             h.write(path);
         });
-#if 0
-        .def("compress", [](const sketch::HyperMinHash &h1, unsigned newnp) {return h1.compress(newnp);},
-             py::return_value_policy::take_ownership,
-             "Compress an HLL sketch from a previous prefix length to a smaller one.")
-#endif
 
     m.def("jaccard_index", [](sketch::HyperMinHash &h1, sketch::HyperMinHash &h2) {
             return jaccard_index(h1, h2);

--- a/python/pysketch.h
+++ b/python/pysketch.h
@@ -77,7 +77,7 @@ struct CmpFunc {
             ptrs[i++] = lp;
         }
         const size_t lsz = l.size(), nc2 = nchoose2(lsz);
-        py::array_t<float> ret({nc2});
+        py::array_t<float> ret({Py_ssize_t(nc2)});
         float *ptr = static_cast<float *>(ret.request().ptr);
         for(size_t i = 0; i < lsz; ++i) {
             OMP_PRAGMA("omp parallel for")


### PR DESCRIPTION
BottomKHasher is more fully-featured as a frontend for FinalRMinHash (faster creation), and HyperMinHash implementations for AVX512 are no longer dependent on AVX512BW, though the code will be faster if it is available.