### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,33 +57,9 @@ All have been accelerated with SIMD parallelism where possible, most are composa
     1. Reference: https://dl.acm.org/doi/10.1016/0022-0000%2885%2990041-8
        Journal of Computer and System Sciences.
        September 1985 https://doi.org/10.1016/0022-0000(85)90041-8
-
-The following sketches are experimental or variations on prior structures
-1. HyperLogFilter [hll.h]
-    1. `hlf_t`/`hlfbase_t<HashStruct>`, `chlf_t`/`chlfbase_t<HashStruct>`
-    2. New data structure which provides the same quantitative accuracy as a HyperLogLog while providing more effective approximate membership query functionality than the HyperLogLog.
-    2. `chlf_t` is identical to the `hlf_t` structure, with the exception that the memory is contiguous and each sketch cannot be used individually.
-    3. Threadsafe unless `-DNOT_THREADSAFE` is passed.
-2. filterhll [filterhll.h]
-    1. `fhll_t`/`fhllbase_t<HashStruct>`
-    2. Simple hll/bf combination without rigorous guarantees for requiring an element be present in the bloom filter to be inserted into the HyperLogLog.
-    3. Currently *not* threadsafe.
-3. Naive Approximate Counting Bloom Filter [cbf.h]
-    1. `cbf_t`/`cbfbase_t<HashStruct>`
-    2. An array of bloom filters where presence in a sketch at a given index replaces the count for the approximate counting algorithm.
-    3. Currently *not* threadsafe.
-7. Probabilistic Counting Bloom Filter
-    1. `pcbf_t`/`pcbfbase_t<HashStruct>`
-    2. An array each of bloom filters and hyperloglogs for approximate counting. The hyperloglogs provide estimated cardinalities for inserted elements, which allows us to estimate the error rates of the bloom filters and therefore account for them in count estimation The hyperloglogs provide estimated cardinalities for inserted elements, which allows us to estimate the error rates of the bloom filters and therefore account for them in count estimation.
-    3. Currently *not* threadsafe.
-8. Multiplicity Adapter
-    1. In `mult.h`, the WeightedSketch template class uses a point querying counting structure (by default, a count-min sketch, but we have observed better results with HeavyKeeper).
-    2. You can find an example of an adapter providing a weighted jaccard HyperLogLog in `test/multtest.cpp`. This works for any of the structures working on unweighted sets.
-
-Future work
-1. Multiplicities
-    1. Consistent Weighted Sampling, Improved CWS
-2. Sampling algorithms and core-sets
+11. SetSketch
+    1. See setsketch.h for continuous and discretized versions of the SetSketch.
+    2. This also includes parameter-setting code.
 
 ### Test case
 To build and run the hll test case:
@@ -93,7 +69,7 @@ make test && ./test
 ```
 
 ### Example
-To use:
+To use as a header-only library:
 
 ```c++
 using namespace sketch;

--- a/include/sketch/bf.h
+++ b/include/sketch/bf.h
@@ -730,8 +730,8 @@ public:
 };
 
 template<typename T, typename Alloc> template<typename Hash>
-sparsebf_t<T, Alloc>::sparsebf_t(const bfbase_t<Hash> &dense): core_(dense.template to_sparse_representation<T, allocator_type>()), nh_(dense.nhashes()), tsz_(dense.m()) {
-    
+sparsebf_t<T, Alloc>::sparsebf_t(const bfbase_t<Hash> &dense): core_(dense.template to_sparse_representation<T, allocator_type>()), nh_(dense.nhashes()), tsz_(dense.m())
+{
 }
 
 using bf_t = bfbase_t<>;

--- a/include/sketch/cbf.h
+++ b/include/sketch/cbf.h
@@ -118,7 +118,7 @@ class pcbfbase_t {
     // Much like cbf_t, but also provides cardinality estimates for the number of elements reaching each stage.
 protected:
     using bf_t  = bf::bfbase_t<HashStruct>;
-    using hll_t = hll::seedhllbase_t<HashStruct>;
+    using hll_t = hll::hllbase_t<HashStruct>;
 
     std::vector<hll_t> hlls_;
     std::vector<bf_t>   bfs_;

--- a/include/sketch/common.h
+++ b/include/sketch/common.h
@@ -361,10 +361,6 @@ static inline double ab2cosine(double alpha, double beta) {
     return (1. - alpha - beta) / std::sqrt((1. - alpha) * (1. - beta));
 }
 
-static inline double g_b(double b, double arg) {
-    return (1 - std::pow(b, -arg)) / (1. - 1. / b);
-}
-
 template<typename T>
 void advise_mem(const T *lhs, const T *rhs, size_t nelem, int advice=MADV_SEQUENTIAL) {
     ::madvise((void *)(lhs), sizeof(T) * nelem, advice);

--- a/include/sketch/common.h
+++ b/include/sketch/common.h
@@ -365,23 +365,10 @@ static inline double g_b(double b, double arg) {
     return (1 - std::pow(b, -arg)) / (1. - 1. / b);
 }
 
-template<typename Container, typename F>
-void for_each_delta_decode(const Container &c, const F &func) {
-    throw NotImplementedError("delta decoding is currently incorrect. DO NOT USE.");
-#if 0
-    using T = std::decay_t<decltype(*std::begin(c))>;
-    auto it = std::begin(c);
-    for(T cv = *it++;;) {
-        func(cv);
-        if(it == std::end(c)) break;
-        else cv += *it++;
-    }
-#endif
-}
 template<typename T>
-void advise_mem(const T *lhs, const T *rhs, size_t nelem) {
-    ::madvise((void *)(lhs), sizeof(T) * nelem, MADV_SEQUENTIAL);
-    ::madvise((void *)(rhs), sizeof(T) * nelem, MADV_SEQUENTIAL);
+void advise_mem(const T *lhs, const T *rhs, size_t nelem, int advice=MADV_SEQUENTIAL) {
+    ::madvise((void *)(lhs), sizeof(T) * nelem, advice);
+    ::madvise((void *)(rhs), sizeof(T) * nelem, advice);
 }
 
 #ifdef __CUDACC__

--- a/include/sketch/common.h
+++ b/include/sketch/common.h
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "unistd.h"
+#include "sys/mman.h"
 
 #include "aesctr/wy.h"
 #include "macros.h"
@@ -356,6 +357,14 @@ std::vector<T, Alloc> delta_encode(const std::vector<T, Alloc> &x) {
     return ret;
 }
 
+static inline double ab2cosine(double alpha, double beta) {
+    return (1. - alpha - beta) / std::sqrt((1. - alpha) * (1. - beta));
+}
+
+static inline double g_b(double b, double arg) {
+    return (1 - std::pow(b, -arg)) / (1. - 1. / b);
+}
+
 template<typename Container, typename F>
 void for_each_delta_decode(const Container &c, const F &func) {
     throw NotImplementedError("delta decoding is currently incorrect. DO NOT USE.");
@@ -368,6 +377,11 @@ void for_each_delta_decode(const Container &c, const F &func) {
         else cv += *it++;
     }
 #endif
+}
+template<typename T>
+void advise_mem(const T *lhs, const T *rhs, size_t nelem) {
+    ::madvise((void *)(lhs), sizeof(T) * nelem, MADV_SEQUENTIAL);
+    ::madvise((void *)(rhs), sizeof(T) * nelem, MADV_SEQUENTIAL);
 }
 
 #ifdef __CUDACC__

--- a/include/sketch/count_eq.h
+++ b/include/sketch/count_eq.h
@@ -18,10 +18,16 @@ static INLINE unsigned int _mm256_movemask_epi16(__m256i x) {
     return _mm_movemask_epi8(_mm_packs_epi16(_mm256_castsi256_si128(x), _mm256_extracti128_si256(x, 1)));
 }
 static INLINE __m256i _mm256_cmpgt_epi8_unsigned(__m256i a, __m256i b) {
-    return _mm256_cmpeq_epi8(a, b) ^ _mm256_cmpeq_epi8(_mm256_max_epu8(a, b), a);
+    return _mm256_andnot_si256(_mm256_cmpeq_epi8(a, b), _mm256_cmpeq_epi8(_mm256_max_epu8(a, b), a));
 }
 static INLINE __m256i _mm256_cmpgt_epi16_unsigned(__m256i a, __m256i b) {
-    return _mm256_cmpeq_epi16(a, b) ^ _mm256_cmpeq_epi16(_mm256_max_epu16(a, b), a);
+    return _mm256_andnot_si256(_mm256_cmpeq_epi16(a, b), _mm256_cmpeq_epi16(_mm256_max_epu16(a, b), a));
+}
+#endif
+
+#if 0 && __AVX512F__
+static INLINE __m512i _mm512_cmpgt_epi16_unsigned(__m512i a, __m512i b) {
+    return _mm512_cmpeq_epi16(a, b) ^ _mm512_cmpeq_epi16(_mm512_max_epu16(a, b), a);
 }
 #endif
 
@@ -445,11 +451,8 @@ static inline std::pair<uint64_t, uint64_t> count_gtlt_shorts(const uint16_t *co
     const size_t nsimd = n / nper;
 #ifndef NDEBUG
     size_t lhgtn = 0, rhgtn = 0;
-    size_t lhgtni = 0, rhgtni = 0;
     for(size_t i = 0; i < n; ++i)
         lhgtn += lhs[i] > rhs[i], rhgtn += rhs[i] > lhs[i];
-    for(size_t i = 0; i < nsimd * nper; ++i)
-        lhgtni += lhs[i] > rhs[i], rhgtni += rhs[i] > lhs[i];
     size_t lhman =0, rhman = 0;
 #endif
     assert(lhs != rhs);

--- a/include/sketch/count_eq.h
+++ b/include/sketch/count_eq.h
@@ -12,6 +12,8 @@ static inline size_t count_eq_nibbles(const uint8_t *SK_RESTRICT lhs, const uint
 static inline size_t count_eq_words(const uint32_t *SK_RESTRICT lhs, const uint32_t *SK_RESTRICT rhs, size_t n);
 static inline size_t count_eq_longs(const uint64_t *SK_RESTRICT lhs, const uint64_t *SK_RESTRICT rhs, size_t n);
 
+
+#ifdef __AVX2__
 static INLINE unsigned int _mm256_movemask_epi16(__m256i x) {
     return _mm_movemask_epi8(_mm_packs_epi16(_mm256_castsi256_si128(x), _mm256_extracti128_si256(x, 1)));
 }
@@ -21,6 +23,7 @@ static INLINE __m256i _mm256_cmpgt_epi8_unsigned(__m256i a, __m256i b) {
 static INLINE __m256i _mm256_cmpgt_epi16_unsigned(__m256i a, __m256i b) {
     return _mm256_cmpeq_epi16(a, b) ^ _mm256_cmpeq_epi16(_mm256_max_epu16(a, b), a);
 }
+#endif
 
 template<typename T>
 static inline size_t count_eq(const T *SK_RESTRICT lhs, const T *SK_RESTRICT rhs, size_t n) {

--- a/include/sketch/count_eq.h
+++ b/include/sketch/count_eq.h
@@ -12,6 +12,14 @@ static inline size_t count_eq_nibbles(const uint8_t *SK_RESTRICT lhs, const uint
 static inline size_t count_eq_words(const uint32_t *SK_RESTRICT lhs, const uint32_t *SK_RESTRICT rhs, size_t n);
 static inline size_t count_eq_longs(const uint64_t *SK_RESTRICT lhs, const uint64_t *SK_RESTRICT rhs, size_t n);
 
+static inline size_t count_eq_bytes_aligned(const uint8_t *SK_RESTRICT lhs, const uint8_t *SK_RESTRICT rhs, size_t n);
+static inline size_t count_eq_shorts_aligned(const uint16_t *SK_RESTRICT lhs, const uint16_t *SK_RESTRICT rhs, size_t n);
+
+static inline std::pair<uint64_t, uint64_t> count_gtlt_bytes(const uint8_t *SK_RESTRICT lhs, const uint8_t *SK_RESTRICT rhs, size_t n);
+static inline std::pair<uint64_t, uint64_t> count_gtlt_shorts(const uint16_t *const SK_RESTRICT lhs, const uint16_t *const SK_RESTRICT rhs, size_t n);
+
+static inline std::pair<uint64_t, uint64_t> count_gtlt_bytes_aligned(const uint8_t *SK_RESTRICT lhs, const uint8_t *SK_RESTRICT rhs, size_t n);
+static inline std::pair<uint64_t, uint64_t> count_gtlt_shorts_aligned(const uint16_t *SK_RESTRICT lhs, const uint16_t *SK_RESTRICT rhs, size_t n);
 
 #ifdef __AVX2__
 static INLINE unsigned int _mm256_movemask_epi16(__m256i x) {
@@ -22,12 +30,6 @@ static INLINE __m256i _mm256_cmpgt_epi8_unsigned(__m256i a, __m256i b) {
 }
 static INLINE __m256i _mm256_cmpgt_epi16_unsigned(__m256i a, __m256i b) {
     return _mm256_andnot_si256(_mm256_cmpeq_epi16(a, b), _mm256_cmpeq_epi16(_mm256_max_epu16(a, b), a));
-}
-#endif
-
-#if 0 && __AVX512F__
-static INLINE __m512i _mm512_cmpgt_epi16_unsigned(__m512i a, __m512i b) {
-    return _mm512_cmpeq_epi16(a, b) ^ _mm512_cmpeq_epi16(_mm512_max_epu16(a, b), a);
 }
 #endif
 
@@ -51,6 +53,11 @@ template<> inline size_t count_eq<uint64_t>(const uint64_t *SK_RESTRICT lhs, con
 }
 
 static inline size_t count_eq_shorts(const uint16_t *SK_RESTRICT lhs, const uint16_t *SK_RESTRICT rhs, size_t n) {
+#if __AVX512F__
+    if(reinterpret_cast<uint64_t>(lhs) % 64 == 0 && reinterpret_cast<uint64_t>(rhs) % 64 == 0) return count_eq_shorts_aligned(lhs, rhs, n);
+#elif __AVX2__
+    if(reinterpret_cast<uint64_t>(lhs) % 32 == 0 && reinterpret_cast<uint64_t>(rhs) % 32 == 0) return count_eq_shorts_aligned(lhs, rhs, n);
+#endif
     advise_mem(lhs, rhs, n);
     size_t ret = 0;
 #if __AVX512BW__
@@ -129,6 +136,85 @@ static inline size_t count_eq_shorts(const uint16_t *SK_RESTRICT lhs, const uint
 #endif
     return ret;
 }
+static inline size_t count_eq_shorts_aligned(const uint16_t *SK_RESTRICT lhs, const uint16_t *SK_RESTRICT rhs, size_t n) {
+    advise_mem(lhs, rhs, n);
+    size_t ret = 0;
+#if __AVX512BW__
+    const size_t nsimd = (n / (sizeof(__m512) / sizeof(uint16_t)));
+    const size_t nsimd4 = (nsimd / 4) * 4;
+    for(size_t i = 0; i < nsimd4; i += 4) {
+        uint64_t v1, v2, v3, v4;
+        v1 = _mm512_cmpeq_epu16_mask(_mm512_load_si512((__m512i *)lhs + i), _mm512_load_si512((__m512i *)rhs + i));
+        v2 = _mm512_cmpeq_epu16_mask(_mm512_load_si512((__m512i *)lhs + i + 1), _mm512_load_si512((__m512i *)rhs + i + 1));
+        ret += popcount((uint64_t(v1) << 32) | v2);
+        v3 = _mm512_cmpeq_epu16_mask(_mm512_load_si512((__m512i *)lhs + i + 2), _mm512_load_si512((__m512i *)rhs + i + 2));
+        v4 = _mm512_cmpeq_epu16_mask(_mm512_load_si512((__m512i *)lhs + i + 3), _mm512_load_si512((__m512i *)rhs + i + 3));
+        ret += popcount((uint64_t(v3) << 32) | v4);
+    }
+    for(size_t i = nsimd4; i < nsimd; ++i)
+        ret += popcount(_mm512_cmpeq_epu16_mask(_mm512_load_si512((__m512i *)lhs + i), _mm512_load_si512((__m512i *)rhs + i)));
+    for(size_t i = nsimd * sizeof(__m512) / sizeof(uint16_t); i < n; ++i)
+        ret += lhs[i] == rhs[i];
+#elif __AVX512F__
+    const size_t nsimd = (n / (sizeof(__m512) / sizeof(uint16_t)));
+    const size_t nsimd4 = (nsimd / 4) * 4;
+    for(size_t i = 0; i < nsimd4; i += 4) {
+        __m512i lhv0 = _mm512_load_si512((__m512i *)lhs + i + 0),
+                rhv0 = _mm512_load_si512((__m512i *)lhs + i + 0);
+        __m512i lhv1 = _mm512_load_si512((__m512i *)lhs + i + 1),
+                rhv1 = _mm512_load_si512((__m512i *)lhs + i + 1);
+        __m512i lhv2 = _mm512_load_si512((__m512i *)lhs + i + 2),
+                rhv2 = _mm512_load_si512((__m512i *)lhs + i + 2);
+        __m512i lhv3 = _mm512_load_si512((__m512i *)lhs + i + 3),
+                rhv3 = _mm512_load_si512((__m512i *)lhs + i + 3);
+        uint64_t eq_hi0 = _mm512_cmpeq_epi32_mask(lhv0 & _mm512_set1_epi32(0x0000FFFFu), rhv0 & _mm512_set1_epi32(0x0000FFFFu));
+        uint64_t eq_lo0 = _mm512_cmpeq_epi32_mask(lhv0 & _mm512_set1_epi32(0xFFFF0000u), rhv0 & _mm512_set1_epi32(0xFFFF0000u));
+        uint64_t eq_hi1 = _mm512_cmpeq_epi32_mask(lhv1 & _mm512_set1_epi32(0x0000FFFFu), rhv1 & _mm512_set1_epi32(0x0000FFFFu));
+        uint64_t eq_lo1 = _mm512_cmpeq_epi32_mask(lhv1 & _mm512_set1_epi32(0xFFFF0000u), rhv1 & _mm512_set1_epi32(0xFFFF0000u));
+        ret += popcount((eq_hi0 << 48) | (eq_hi1 << 32) | (eq_lo0 << 16) | eq_lo1);
+        uint64_t eq_hi2 = _mm512_cmpeq_epi32_mask(lhv2 & _mm512_set1_epi32(0x0000FFFFu), rhv2 & _mm512_set1_epi32(0x0000FFFFu));
+        uint64_t eq_lo2 = _mm512_cmpeq_epi32_mask(lhv2 & _mm512_set1_epi32(0xFFFF0000u), rhv2 & _mm512_set1_epi32(0xFFFF0000u));
+        uint64_t eq_hi3 = _mm512_cmpeq_epi32_mask(lhv3 & _mm512_set1_epi32(0x0000FFFFu), rhv3 & _mm512_set1_epi32(0x0000FFFFu));
+        uint64_t eq_lo3 = _mm512_cmpeq_epi32_mask(lhv3 & _mm512_set1_epi32(0xFFFF0000u), rhv3 & _mm512_set1_epi32(0xFFFF0000u));
+        ret += popcount((eq_hi2 << 48) | (eq_hi3 << 32) | (eq_lo2 << 16) | eq_lo3);
+    }
+    for(size_t i = nsimd4; i < nsimd; ++i) {
+        __m512i lhv0 = _mm512_load_si512((__m512i *)lhs + i + 0),
+                rhv0 = _mm512_load_si512((__m512i *)lhs + i + 0);
+        uint64_t eq_hi0 = _mm512_cmpeq_epi32_mask(lhv0 & _mm512_set1_epi32(0x0000FFFFu), rhv0 & _mm512_set1_epi32(0x0000FFFFu));
+        ret += popcount((eq_hi0 << 16) | _mm512_cmpeq_epi32_mask(lhv0 & _mm512_set1_epi32(0xFFFF0000u), rhv0 & _mm512_set1_epi32(0xFFFF0000u)));
+    }
+    for(size_t i = nsimd * sizeof(__m512) / sizeof(uint16_t); i < n; ++i)
+        ret += lhs[i] == rhs[i];
+#elif __AVX2__
+    const size_t nsimd = (n / (sizeof(__m256) / sizeof(uint16_t)));
+    const size_t nsimd4 = (nsimd / 4) * 4;
+    // Each vector register has at most 16 1-bits, so we can pack the bitmasks into 4 uint64_t popcounts.
+    for(size_t i = 0; i < nsimd4; i += 4) {
+        auto eq_reg = _mm256_cmpeq_epi16(_mm256_load_si256((__m256i*)lhs + i), _mm256_load_si256((__m256i*)rhs + i));
+        auto bitmask = _mm256_movemask_epi16(eq_reg);
+        auto eq_reg2 = _mm256_cmpeq_epi16(_mm256_load_si256((__m256i*)lhs + i + 1), _mm256_load_si256((__m256i*)rhs + i + 1));
+        auto bitmask2 = _mm256_movemask_epi16(eq_reg2);
+        auto eq_reg3 = _mm256_cmpeq_epi16(_mm256_load_si256((__m256i*)lhs + i + 2), _mm256_load_si256((__m256i*)rhs + i + 2));
+        auto bitmask3 = _mm256_movemask_epi16(eq_reg3);
+        auto eq_reg4 = _mm256_cmpeq_epi16(_mm256_load_si256((__m256i*)lhs + i + 3), _mm256_load_si256((__m256i*)rhs + i + 3));
+        auto bitmask4 = _mm256_movemask_epi16(eq_reg4);
+        ret += popcount((uint64_t(bitmask) << 48) | (uint64_t(bitmask2) << 32) | (uint64_t(bitmask3) << 16) | bitmask4);
+    }
+    for(size_t i = nsimd4; i < nsimd; ++i) {
+        auto eq_reg = _mm256_cmpeq_epi16(_mm256_load_si256((__m256i*)lhs + i), _mm256_load_si256((__m256i*)rhs + i));
+        auto bitmask = _mm256_movemask_epi16(eq_reg);
+        ret += popcount(bitmask);
+    }
+    for(size_t i = nsimd * sizeof(__m256) / sizeof(uint16_t); i < n; ++i)
+        ret += lhs[i] == rhs[i];
+#else
+    for(size_t i = 0; i < n; ++i) {
+        ret += lhs[i] == rhs[i];
+    }
+#endif
+    return ret;
+}
 
 static inline size_t count_eq_longs(const uint64_t *SK_RESTRICT lhs, const uint64_t *SK_RESTRICT rhs, size_t n) {
     advise_mem(lhs, rhs, n);
@@ -184,6 +270,11 @@ static inline size_t count_eq_nibbles(const uint8_t *SK_RESTRICT lhs, const uint
 }
 
 static inline size_t count_eq_bytes(const uint8_t *SK_RESTRICT lhs, const uint8_t *SK_RESTRICT rhs, size_t n) {
+#if __AVX512F__
+    if(reinterpret_cast<uint64_t>(lhs) % 64 == 0 && reinterpret_cast<uint64_t>(rhs) % 64 == 0) return count_eq_bytes_aligned(lhs, rhs, n);
+#elif __AVX2__
+    if(reinterpret_cast<uint64_t>(lhs) % 32 == 0 && reinterpret_cast<uint64_t>(rhs) % 32 == 0) return count_eq_bytes_aligned(lhs, rhs, n);
+#endif
     advise_mem(lhs, rhs, n);
     size_t ret = 0;
 #if __AVX512BW__
@@ -243,9 +334,67 @@ static inline size_t count_eq_bytes(const uint8_t *SK_RESTRICT lhs, const uint8_
 #endif
     return ret;
 }
+static inline size_t count_eq_bytes_aligned(const uint8_t *SK_RESTRICT lhs, const uint8_t *SK_RESTRICT rhs, size_t n) {
+    advise_mem(lhs, rhs, n);
+    size_t ret = 0;
+#if __AVX512BW__
+    const size_t nsimd = (n / (sizeof(__m512) / sizeof(char)));
+    const size_t nsimd4 = (nsimd / 4) * 4;
+    for(size_t i = 0; i < nsimd4; i += 4) {
+        ret += popcount(_mm512_cmpeq_epi8_mask(_mm512_load_si512((__m512i *)lhs + i), _mm512_load_si512((__m512i *)rhs + i)));
+        ret += popcount(_mm512_cmpeq_epi8_mask(_mm512_load_si512((__m512i *)lhs + i + 1), _mm512_load_si512((__m512i *)rhs + i + 1)));
+        ret += popcount(_mm512_cmpeq_epi8_mask(_mm512_load_si512((__m512i *)lhs + i + 2), _mm512_load_si512((__m512i *)rhs + i + 2)));
+        ret += popcount(_mm512_cmpeq_epi8_mask(_mm512_load_si512((__m512i *)lhs + i + 3), _mm512_load_si512((__m512i *)rhs + i + 3)));
+    }
+    for(size_t i = nsimd4; i < nsimd; ++i)
+        ret += popcount(_mm512_cmpeq_epi8_mask(_mm512_load_si512((__m512i *)lhs + i), _mm512_load_si512((__m512i *)rhs + i)));
+    for(size_t i = nsimd * sizeof(__m512) / sizeof(char); i < n; ++i)
+        ret += lhs[i] == rhs[i];
+#elif __AVX512F__
+    const size_t nsimd = (n / (sizeof(__m512) / sizeof(char)));
+    const size_t nsimd4 = (nsimd / 4) * 4;
+#define POPC_CMP(lhv, rhv) popcount(\
+                  (uint64_t(_mm512_cmpeq_epi32_mask(_mm512_slli_epi32(lhv, 24), _mm512_slli_epi32(rhv, 24))) << 48) |\
+                  (uint64_t(_mm512_cmpeq_epi32_mask(lhv & _mm512_set1_epi32(0x0000FF00u), rhv & _mm512_set1_epi32(0x0000FF00u))) << 32) |\
+                  (uint64_t(_mm512_cmpeq_epi32_mask(lhv & _mm512_set1_epi32(0x00FF0000u), rhv & _mm512_set1_epi32(0x00FF0000u))) << 16) |\
+                  _mm512_cmpeq_epi32_mask(_mm512_srli_epi32(lhv, 24), _mm512_srli_epi32(rhv, 24)))
+    for(size_t i = 0; i < nsimd4; i += 4) {
+        const __m512i lhv = _mm512_load_si512((__m512i *)lhs + i), rhv = _mm512_load_si512((__m512i *)rhs + i);
+        const __m512i lhv1 = _mm512_load_si512((__m512i *)lhs + i + 1), rhv1 = _mm512_load_si512((__m512i *)rhs + i + 1);
+        const __m512i lhv2 = _mm512_load_si512((__m512i *)lhs + i + 2), rhv2 = _mm512_load_si512((__m512i *)rhs + i + 2);
+        const __m512i lhv3 = _mm512_load_si512((__m512i *)lhs + i + 3), rhv3 = _mm512_load_si512((__m512i *)rhs + i + 3);
+        ret += POPC_CMP(lhv, rhv);
+        ret += POPC_CMP(lhv1, rhv1);
+        ret += POPC_CMP(lhv2, rhv2);
+        ret += POPC_CMP(lhv3, rhv3);
+    }
+    for(size_t i = nsimd4; i < nsimd; ++i) {
+        const __m512i lhv = _mm512_load_si512((__m512i *)lhs + i), rhv = _mm512_load_si512((__m512i *)rhs + i);
+        ret += POPC_CMP(lhv, rhv);
+    }
+#undef POPC_CMP
+    for(size_t i = nsimd * sizeof(__m512) / sizeof(char); i < n; ++i) ret += lhs[i] == rhs[i];
+#elif __AVX2__
+    const size_t nsimd = (n / (sizeof(__m256) / sizeof(char)));
+    const size_t nsimd4 = (nsimd / 4) * 4;
+    for(size_t i = 0; i < nsimd4; i += 4) {
+        const uint64_t v0 = _mm256_movemask_epi8(_mm256_cmpeq_epi8(_mm256_load_si256((__m256i *)lhs + i), _mm256_load_si256((__m256i *)rhs + i)));
+        ret += popcount((v0 << 32) | _mm256_movemask_epi8(_mm256_cmpeq_epi8(_mm256_load_si256((__m256i *)lhs + i + 1), _mm256_load_si256((__m256i *)rhs + i + 1))));
+        const uint64_t v2 = _mm256_movemask_epi8(_mm256_cmpeq_epi8(_mm256_load_si256((__m256i *)lhs + i + 2), _mm256_load_si256((__m256i *)rhs + i + 2)));
+        ret += popcount((v2 << 32) | _mm256_movemask_epi8(_mm256_cmpeq_epi8(_mm256_load_si256((__m256i *)lhs + i + 3), _mm256_load_si256((__m256i *)rhs + i + 3))));
+    }
+    for(size_t i = nsimd4; i < nsimd; ++i)
+        ret += popcount(_mm256_movemask_epi8(_mm256_cmpeq_epi8(_mm256_load_si256((__m256i *)lhs + i), _mm256_load_si256((__m256i *)rhs + i))));
+    for(size_t i = nsimd * sizeof(__m256) / sizeof(char); i < n; ++i)
+        ret += lhs[i] == rhs[i];
+#else
+    for(size_t i = 0; i < n; ++i) {
+        ret += lhs[i] == rhs[i];
+    }
+#endif
+    return ret;
+}
 
-static inline std::pair<uint64_t, uint64_t> count_gtlt_bytes(const uint8_t *SK_RESTRICT lhs, const uint8_t *SK_RESTRICT rhs, size_t n);
-static inline std::pair<uint64_t, uint64_t> count_gtlt_shorts(const uint16_t *const SK_RESTRICT lhs, const uint16_t *const SK_RESTRICT rhs, size_t n);
 template<typename T>
 static inline std::pair<uint64_t, uint64_t> count_gtlt(const T *SK_RESTRICT lhs, const T *SK_RESTRICT rhs, size_t n) {
     uint64_t lhgt = 0, rhgt = 0;
@@ -303,15 +452,14 @@ static inline std::pair<uint64_t, uint64_t> count_gtlt_bytes(const uint8_t *SK_R
 #elif __AVX2__
     const size_t nper = sizeof(__m256);
     const size_t nsimd = n / nper;
+    SK_UNROLL_4
     for(size_t i = 0; i < nsimd; ++i) {
-        auto lhv = _mm256_loadu_si256((__m256i *)lhs + i);
-        auto rhv = _mm256_loadu_si256((__m256i *)rhs + i);
+        const auto lhv = _mm256_loadu_si256((__m256i *)lhs + i), rhv = _mm256_loadu_si256((__m256i *)rhs + i);
         lhgt += popcount(_mm256_movemask_epi8(_mm256_cmpgt_epi8_unsigned(lhv, rhv)));
         rhgt += popcount(_mm256_movemask_epi8(_mm256_cmpgt_epi8_unsigned(rhv, lhv)));
     }
     for(size_t i = nsimd * nper; i < n; ++i) {
-        lhgt += lhs[i] > rhs[i];
-        rhgt += rhs[i] > lhs[i];
+        lhgt += lhs[i] > rhs[i]; rhgt += rhs[i] > lhs[i];
     }
 #else
     for(size_t i = 0; i < n; ++i) {
@@ -321,6 +469,72 @@ static inline std::pair<uint64_t, uint64_t> count_gtlt_bytes(const uint8_t *SK_R
 #endif
     return std::make_pair(lhgt, rhgt);
 }
+
+static inline std::pair<uint64_t, uint64_t> count_gtlt_bytes_aligned(const uint8_t *SK_RESTRICT lhs, const uint8_t *SK_RESTRICT rhs, size_t n) {
+#if __AVX512F__
+    if(reinterpret_cast<uint64_t>(lhs) % 64 == 0 && reinterpret_cast<uint64_t>(rhs) % 64 == 0) return count_gtlt_bytes_aligned(lhs, rhs, n);
+#elif __AVX2__
+    if(reinterpret_cast<uint64_t>(lhs) % 32 == 0 && reinterpret_cast<uint64_t>(rhs) % 32 == 0) return count_gtlt_bytes_aligned(lhs, rhs, n);
+#endif
+    uint64_t lhgt = 0, rhgt = 0;
+#if __AVX512BW__
+    const size_t nper = sizeof(__m512);
+    const size_t nsimd = n / nper;
+    for(size_t i = 0; i < nsimd; ++i) {
+        auto lhv = _mm512_load_si512((__m512i *)lhs + i);
+        auto rhv = _mm512_load_si512((__m512i *)rhs + i);
+        uint64_t v0 = _mm512_cmpgt_epu8_mask(lhv, rhv);
+        uint64_t v1 = _mm512_cmpgt_epu8_mask(rhv, lhv);
+        lhgt += popcount(v0);
+        rhgt += popcount(v1);
+    }
+    for(size_t i = nsimd * nper; i < n; ++i) {
+        lhgt += lhs[i] > rhs[i];
+        rhgt += rhs[i] > lhs[i];
+    }
+#elif __AVX512F__
+    const size_t nper = sizeof(__m512);
+    const size_t nsimd = n / nper;
+    for(size_t i = 0; i < nsimd; ++i) {
+        auto lhv = _mm512_load_si512((__m512i *)lhs + i);
+        auto rhv = _mm512_load_si512((__m512i *)rhs + i);
+        auto lhsd = _mm512_srli_epi32(lhv, 24), rhsd =  _mm512_srli_epi32(rhv, 24);
+        auto lhsu = _mm512_slli_epi32(lhv, 24), rhsu = _mm512_slli_epi32(rhv, 24);
+        auto ulmask = _mm512_set1_epi32(0x00FF0000u), llmask = _mm512_set1_epi32(0x0000FF00u);
+        lhgt += popcount((uint64_t(_mm512_cmpgt_epi32_mask(lhsd, rhsd)) << 48) |
+                       (uint64_t(_mm512_cmpgt_epi32_mask(lhv & ulmask, rhv & ulmask)) << 32) |
+                       (uint64_t(_mm512_cmpgt_epi32_mask(lhv & llmask, rhv & llmask)) << 16) |
+                       _mm512_cmpgt_epi32_mask(lhsu, rhsu));
+        rhgt += popcount((uint64_t(_mm512_cmpgt_epi32_mask(rhsd, lhsd)) << 48) |
+                       (uint64_t(_mm512_cmpgt_epi32_mask(rhv & ulmask, lhv & ulmask)) << 32) |
+                       (uint64_t(_mm512_cmpgt_epi32_mask(rhv & llmask, lhv & llmask)) << 16) |
+                       _mm512_cmpgt_epi32_mask(rhsu, lhsu));
+    }
+    for(size_t i = nsimd * nper; i < n; ++i) {
+        lhgt += lhs[i] > rhs[i];
+        rhgt += rhs[i] > lhs[i];
+    }
+#elif __AVX2__
+    const size_t nper = sizeof(__m256);
+    const size_t nsimd = n / nper;
+    SK_UNROLL_4
+    for(size_t i = 0; i < nsimd; ++i) {
+        const auto lhv = _mm256_load_si256((__m256i *)lhs + i), rhv = _mm256_load_si256((__m256i *)rhs + i);
+        lhgt += popcount(_mm256_movemask_epi8(_mm256_cmpgt_epi8_unsigned(lhv, rhv)));
+        rhgt += popcount(_mm256_movemask_epi8(_mm256_cmpgt_epi8_unsigned(rhv, lhv)));
+    }
+    for(size_t i = nsimd * nper; i < n; ++i) {
+        lhgt += lhs[i] > rhs[i]; rhgt += rhs[i] > lhs[i];
+    }
+#else
+    for(size_t i = 0; i < n; ++i) {
+        lhgt += lhs[i] > rhs[i];
+        rhgt += rhs[i] > lhs[i];
+    }
+#endif
+    return std::make_pair(lhgt, rhgt);
+}
+
 static inline std::pair<uint64_t, uint64_t> count_gtlt_nibbles(const uint8_t *SK_RESTRICT lhs, const uint8_t *SK_RESTRICT rhs, size_t nelem) {
     uint64_t lhgt = 0, rhgt = 0;
     const size_t n = nelem >> 1;
@@ -352,9 +566,7 @@ static inline std::pair<uint64_t, uint64_t> count_gtlt_nibbles(const uint8_t *SK
     const size_t nsimd = n / nper;
     auto lomask = _mm256_set1_epi8(0xFu);
     auto himask = _mm256_set1_epi8(static_cast<unsigned char>(0xF0u));
-#ifdef __GNUC__
-    #pragma GCC unroll 4
-#endif
+    SK_UNROLL_4
     for(size_t i = 0; i < nsimd; ++i) {
         auto lhv = _mm256_loadu_si256((__m256i *)lhs + i);
         auto rhv = _mm256_loadu_si256((__m256i *)rhs + i);
@@ -386,8 +598,12 @@ static inline std::pair<uint64_t, uint64_t> count_gtlt_nibbles(const uint8_t *SK
     return std::make_pair(lhgt, rhgt);
 }
 
-
 static inline std::pair<uint64_t, uint64_t> count_gtlt_shorts(const uint16_t *const SK_RESTRICT lhs, const uint16_t *const SK_RESTRICT rhs, size_t n) {
+#if __AVX512F__
+    if(reinterpret_cast<uint64_t>(lhs) % 64 == 0 && reinterpret_cast<uint64_t>(rhs) % 64 == 0) return count_gtlt_shorts_aligned(lhs, rhs, n);
+#elif __AVX2__
+    if(reinterpret_cast<uint64_t>(lhs) % 32 == 0 && reinterpret_cast<uint64_t>(rhs) % 32 == 0) return count_gtlt_shorts_aligned(lhs, rhs, n);
+#endif
     uint64_t lhgt = 0, rhgt = 0;
 #if __AVX512BW__
     const size_t nper = sizeof(__m512) / sizeof(uint16_t);
@@ -449,28 +665,93 @@ static inline std::pair<uint64_t, uint64_t> count_gtlt_shorts(const uint16_t *co
 #elif __AVX2__
     const size_t nper = sizeof(__m256) / sizeof(uint16_t);
     const size_t nsimd = n / nper;
-#ifndef NDEBUG
-    size_t lhgtn = 0, rhgtn = 0;
-    for(size_t i = 0; i < n; ++i)
-        lhgtn += lhs[i] > rhs[i], rhgtn += rhs[i] > lhs[i];
-    size_t lhman =0, rhman = 0;
-#endif
     assert(lhs != rhs);
+    SK_UNROLL_4
     for(size_t i = 0; i < nsimd; ++i) {
         const auto lhv = _mm256_loadu_si256((__m256i *)lhs + i);
         const auto rhv = _mm256_loadu_si256((__m256i *)rhs + i);
-        assert(std::equal((uint16_t *)((__m256i *)lhs + i), (uint16_t *)((__m256i *)lhs + i) + 16, (uint16_t *)&lhv));
-        assert(std::equal((uint16_t *)((__m256i *)rhs + i), (uint16_t *)((__m256i *)rhs + i) + 16, (uint16_t *)&rhv));
-#ifndef NDEBUG
-        for(size_t j = 0; j < nper; ++j) {
-            lhman += lhs[i * nper + j] > rhs[i * nper + j];
-            rhman += rhs[i * nper + j] > lhs[i * nper + j];
-        }
-#endif
         lhgt += popcount(_mm256_movemask_epi16(_mm256_cmpgt_epi16_unsigned(lhv, rhv)));
         rhgt += popcount(_mm256_movemask_epi16(_mm256_cmpgt_epi16_unsigned(rhv, lhv)));
-        assert(lhgt == lhman || !std::fprintf(stderr, "lhgt %zu, lhman %zu\n", size_t(lhgt), lhman));
-        assert(rhgt == rhman || !std::fprintf(stderr, "rhgt %zu, rhman %zu\n", size_t(rhgt), rhman));
+    }
+    for(size_t i = nper * nsimd; i < n; ++i) {
+        const auto lhv = lhs[i], rhv = rhs[i];
+        lhgt += (lhv > rhv); rhgt += (rhv > lhv);
+    }
+#else
+    SK_UNROLL_4
+    for(size_t i = 0; i < n; ++i) {
+        lhgt += lhs[i] > rhs[i];
+        rhgt += rhs[i] > lhs[i];
+    }
+#endif
+    return std::make_pair(lhgt, rhgt);
+}
+
+static inline std::pair<uint64_t, uint64_t> count_gtlt_shorts_aligned(const uint16_t *const SK_RESTRICT lhs, const uint16_t *const SK_RESTRICT rhs, size_t n) {
+    uint64_t lhgt = 0, rhgt = 0;
+#if __AVX512BW__
+    const size_t nper = sizeof(__m512) / sizeof(uint16_t);
+    const size_t nsimd = n / nper;
+    const size_t nsimd4 = (nsimd / 4) * 4;
+    for(size_t i = 0; i < nsimd4; i += 4) {
+        auto lhv0 = _mm512_load_si512((__m512i *)lhs + i);
+        auto rhv0 = _mm512_load_si512((__m512i *)rhs + i);
+        uint64_t lv0 = _mm512_cmpgt_epu16_mask(lhv0, rhv0);
+        uint64_t rv0 = _mm512_cmpgt_epu16_mask(rhv0, lhv0);
+        auto lhv1 = _mm512_load_si512((__m512i *)lhs + (i + 1));
+        auto rhv1 = _mm512_load_si512((__m512i *)rhs + (i + 1));
+        lv0 = (lv0 << 32) | _mm512_cmpgt_epu16_mask(lhv1, rhv1);
+        rv0 = (rv0 << 32) | _mm512_cmpgt_epu16_mask(rhv1, lhv1);
+        lhgt += popcount(lv0);
+        rhgt += popcount(rv0);
+        auto lhv2 = _mm512_load_si512((__m512i *)lhs + (i + 2));
+        auto rhv2 = _mm512_load_si512((__m512i *)rhs + (i + 2));
+        lv0 = _mm512_cmpgt_epu16_mask(lhv2, rhv2);
+        rv0 = _mm512_cmpgt_epu16_mask(rhv2, lhv2);
+        auto lhv3 = _mm512_load_si512((__m512i *)lhs + (i + 3));
+        auto rhv3 = _mm512_load_si512((__m512i *)rhs + (i + 3));
+        lv0 = (lv0 << 32) | _mm512_cmpgt_epu16_mask(lhv3, rhv3);
+        rv0 = (rv0 << 32) | _mm512_cmpgt_epu16_mask(rhv3, lhv3);
+        lhgt += popcount(lv0);
+        rhgt += popcount(rv0);
+    }
+    for(size_t i = nsimd4; i < nsimd; ++i) {
+        auto lhv = _mm512_load_si512((__m512i *)lhs + i);
+        auto rhv = _mm512_load_si512((__m512i *)rhs + i);
+        uint64_t v0 = _mm512_cmpgt_epu16_mask(lhv, rhv);
+        uint64_t v1 = _mm512_cmpgt_epu16_mask(rhv, lhv);
+        lhgt += popcount(v0);
+        rhgt += popcount(v1);
+    }
+    for(size_t i = nsimd * nper; i < n; ++i) {
+        lhgt += lhs[i] > rhs[i];
+        rhgt += rhs[i] > lhs[i];
+    }
+#elif __AVX512F__
+    const size_t nper = sizeof(__m512) / sizeof(uint16_t);
+    const size_t nsimd = n / nper;
+    SK_UNROLL_4
+    for(size_t i = 0; i < nsimd; ++i) {
+        __m512i lhv, rhv, lhsu, rhsu;
+        lhv = _mm512_load_si512((__m512i *)lhs + i); rhv = _mm512_load_si512((__m512i *)rhs + i);
+        lhsu = _mm512_slli_epi32(lhv, 16); rhsu = _mm512_slli_epi32(rhv, 16);
+        lhv = _mm512_srli_epi32(lhv, 16);  rhv = _mm512_srli_epi32(rhv, 16);
+        lhgt += popcount((_mm512_cmpgt_epi32_mask(lhsu, rhsu) << 16) | _mm512_cmpgt_epi32_mask(lhv, rhv));
+        rhgt += popcount((_mm512_cmpgt_epi32_mask(rhsu, lhsu) << 16) | _mm512_cmpgt_epi32_mask(rhv, lhv));
+    }
+    for(size_t i = nsimd * nper; i < n; ++i) {
+        lhgt += lhs[i] > rhs[i];
+        rhgt += rhs[i] > lhs[i];
+    }
+#elif __AVX2__
+    const size_t nper = sizeof(__m256) / sizeof(uint16_t);
+    const size_t nsimd = n / nper;
+    SK_UNROLL_4
+    for(size_t i = 0; i < nsimd; ++i) {
+        const auto lhv = _mm256_load_si256((__m256i *)lhs + i);
+        const auto rhv = _mm256_load_si256((__m256i *)rhs + i);
+        lhgt += popcount(_mm256_movemask_epi16(_mm256_cmpgt_epi16_unsigned(lhv, rhv)));
+        rhgt += popcount(_mm256_movemask_epi16(_mm256_cmpgt_epi16_unsigned(rhv, lhv)));
     }
     for(size_t i = nper * nsimd; i < n; ++i) {
         const auto lhv = lhs[i], rhv = rhs[i];

--- a/include/sketch/count_eq.h
+++ b/include/sketch/count_eq.h
@@ -13,12 +13,6 @@ static inline size_t count_eq_words(const uint32_t *SK_RESTRICT lhs, const uint3
 static inline size_t count_eq_longs(const uint64_t *SK_RESTRICT lhs, const uint64_t *SK_RESTRICT rhs, size_t n);
 
 template<typename T>
-void advise_mem(const T *lhs, const T *rhs, size_t nbytes) {
-    ::madvise((void *)(lhs), nbytes, MADV_SEQUENTIAL);
-    ::madvise((void *)(rhs), nbytes, MADV_SEQUENTIAL);
-}
-
-template<typename T>
 static inline size_t count_eq(const T *SK_RESTRICT lhs, const T *SK_RESTRICT rhs, size_t n) {
     size_t ret = 0;
     for(size_t i = 0; i < n; ++i) ret += lhs[i] == rhs[i];
@@ -38,7 +32,7 @@ template<> inline size_t count_eq<uint64_t>(const uint64_t *SK_RESTRICT lhs, con
 }
 
 static inline size_t count_eq_shorts(const uint16_t *SK_RESTRICT lhs, const uint16_t *SK_RESTRICT rhs, size_t n) {
-    advise_mem(lhs, rhs, n * sizeof(*lhs));
+    advise_mem(lhs, rhs, n);
     size_t ret = 0;
 #if __AVX512BW__
     const size_t nsimd = (n / (sizeof(__m512) / sizeof(uint16_t)));
@@ -93,20 +87,20 @@ static inline size_t count_eq_shorts(const uint16_t *SK_RESTRICT lhs, const uint
 }
 
 static inline size_t count_eq_longs(const uint64_t *SK_RESTRICT lhs, const uint64_t *SK_RESTRICT rhs, size_t n) {
-    advise_mem(lhs, rhs, n * sizeof(*lhs));
+    advise_mem(lhs, rhs, n);
     size_t ret = 0;
     for(size_t i = 0; i < n; ++i) ret += lhs[i] == rhs[i];
     return ret;
 }
 
 static inline size_t count_eq_words(const uint32_t *SK_RESTRICT lhs, const uint32_t *SK_RESTRICT rhs, size_t n) {
-    advise_mem(lhs, rhs, n * sizeof(*lhs));
+    advise_mem(lhs, rhs, n);
     size_t ret = 0;
     for(size_t i = 0; i < n; ++i) ret += lhs[i] == rhs[i];
     return ret;
 }
 static inline size_t count_eq_nibbles(const uint8_t *SK_RESTRICT lhs, const uint8_t *SK_RESTRICT rhs, size_t n) {
-    advise_mem(lhs, rhs, n * sizeof(*lhs));
+    advise_mem(lhs, rhs, n);
     n >>= 1;
     size_t ret = 0;
 #if __AVX512BW__
@@ -141,7 +135,7 @@ static inline size_t count_eq_nibbles(const uint8_t *SK_RESTRICT lhs, const uint
 }
 
 static inline size_t count_eq_bytes(const uint8_t *SK_RESTRICT lhs, const uint8_t *SK_RESTRICT rhs, size_t n) {
-    advise_mem(lhs, rhs, n * sizeof(*lhs));
+    advise_mem(lhs, rhs, n);
     size_t ret = 0;
 #if __AVX512BW__
     const size_t nsimd = (n / (sizeof(__m512) / sizeof(char)));
@@ -176,42 +170,6 @@ static inline size_t count_eq_bytes(const uint8_t *SK_RESTRICT lhs, const uint8_
 #endif
     return ret;
 }
-#if 0
-static inline std::pair<uint32_t, uint32_t> count_eq_and_nonzero_bytes(const uint8_t *SK_RESTRICT lhs, const uint8_t *SK_RESTRICT rhs, size_t n) {
-    size_t ret = 0, nnz = 0;
-#if __AVX512BW__
-    const size_t nsimd = (n / (sizeof(__m512) / sizeof(char)));
-    for(size_t i = 0; i < nsimd; ++i) {
-        auto lh0 = _mm512_loadu_si512((__m512i *)lhs + i), rh0 = _mm512_loadu_si512((__m512i *)rhs + i);
-        auto lheq0 = _mm512_cmpeq_epi8_mask(lh0, _mm512_setzero()), rheq0 = _mm512_cmpeq_epi8_mask(rh0, _mm512_setzero());
-        auto beq0 = ~lheq0 & ~rheq0;
-        ret += popcount(_mm512_cmpeq_epi8_mask(lh0, rh0) & beq0);
-        nnz += popcount(beq0);
-    }
-    for(size_t i = nsimd * sizeof(__m512) / sizeof(char); i < n; ++i)
-        if(lhs[i] && rhs[i]) ret += lhs[i] == rhs[i], ++nnz;
-#elif __AVX2__
-    const size_t nsimd = (n / (sizeof(__m256) / sizeof(char)));
-    const size_t nsimd4 = (nsimd / 4) * 4;
-    for(size_t i = 0; i < nsimd4; i += 4) {
-        const uint64_t v0 = _mm256_movemask_epi8(_mm256_cmpeq_epi8(_mm256_loadu_si256((__m256i *)lhs + i), _mm256_loadu_si256((__m256i *)rhs + i)));
-        ret += popcount((v0 << 32) | _mm256_movemask_epi8(_mm256_cmpeq_epi8(_mm256_loadu_si256((__m256i *)lhs + i + 1), _mm256_loadu_si256((__m256i *)rhs + i + 1))));
-        const uint64_t v2 = _mm256_movemask_epi8(_mm256_cmpeq_epi8(_mm256_loadu_si256((__m256i *)lhs + i + 2), _mm256_loadu_si256((__m256i *)rhs + i + 2)));
-        ret += popcount((v2 << 32) | _mm256_movemask_epi8(_mm256_cmpeq_epi8(_mm256_loadu_si256((__m256i *)lhs + i + 3), _mm256_loadu_si256((__m256i *)rhs + i + 3))));
-    }
-    for(size_t i = nsimd4; i < nsimd; ++i)
-        ret += popcount(_mm256_movemask_epi8(_mm256_cmpeq_epi8(_mm256_loadu_si256((__m256i *)lhs + i), _mm256_loadu_si256((__m256i *)rhs + i))));
-    for(size_t i = nsimd * sizeof(__m256) / sizeof(char); i < n; ++i)
-        ret += lhs[i] == rhs[i];
-#else
-    for(size_t i = 0; i < n; ++i) {
-        ret += lhs[i] == rhs[i];
-    }
-#endif
-    return ret;
-}
-#endif
-
 
 }} // sketch::eq
 

--- a/include/sketch/fy.h
+++ b/include/sketch/fy.h
@@ -1,0 +1,63 @@
+#ifndef WMH_FY_H__
+#define WMH_FY_H__
+#include <div.h>
+#include <vector>
+#include <cstdlib>
+#include <memory>
+#include "aesctr/wy.h"
+#include <cassert>
+
+namespace fisher_yates {
+
+using std::size_t;
+
+struct LazyShuffler {
+    // Algorithm 6, https://arxiv.org/pdf/1911.00675.pdf
+    // Uses 32-bit integers for cheaper modulo reductions,
+    // and uses the fastmod https://arxiv.org/abs/1902.01961 trick
+    using IT = uint32_t;
+private:
+    std::vector<IT> data_;
+    wy::WyRand<uint32_t, 4> rng_;
+    size_t i_ = 0, c_ = 0, sz_;
+    std::vector<schism::Schismatic<IT>> divs_;
+
+
+    IT &getg(size_t i) {return data_[i << 1];}
+    IT &getv(size_t i) {return data_[(i << 1) + 1];}
+public:
+    LazyShuffler(size_t n, uint64_t seed=0): data_(n * 2), rng_(seed), sz_(n) {
+        divs_.reserve(n);
+        for(size_t i = 0; i < n; ++i)
+            divs_.emplace_back(n - i);
+        reset();
+    }
+    size_t size() const {return sz_;}
+    IT step() {
+        IT samp = divs_[i_].mod(rng_());
+        IT j = i_ + samp;
+        assert(j < size());
+        IT &gj = getg(j);
+        const IT &gi = getg(i_);
+        IT &vj = getv(j);
+        const IT k  = vj  == c_ ? gj: j;
+        gj = getv(i_) == c_ ? gi: i_;
+        vj = c_;
+        ++i_;
+        return k;
+    }
+    bool has_next() {return i_ < sz_;}
+    void seed(uint64_t seed) {
+        rng_.seed(seed);
+    }
+    void reset() {
+        i_ = 0;
+        ++c_;
+    }
+};
+
+} // namespace fisher_yates
+
+namespace fy = fisher_yates;
+
+#endif

--- a/include/sketch/fy.h
+++ b/include/sketch/fy.h
@@ -50,6 +50,15 @@ public:
     void seed(uint64_t seed) {
         rng_.seed(seed);
     }
+    void resize(size_t newsize, uint64_t seed=0) {
+        data_.resize(newsize * 2);
+        std::fill(data_.begin(), data_.end(), IT(0));
+        divs_.clear();
+        for(size_t i = 0; i < newsize; ++i)
+            divs_.emplace_back(newsize - i);
+        rng_.seed(seed);
+        reset();
+    }
     void reset() {
         i_ = 0;
         ++c_;

--- a/include/sketch/fy.h
+++ b/include/sketch/fy.h
@@ -1,6 +1,6 @@
 #ifndef WMH_FY_H__
 #define WMH_FY_H__
-#include <div.h>
+#include "sketch/div.h"
 #include <vector>
 #include <cstdlib>
 #include <memory>

--- a/include/sketch/hll.h
+++ b/include/sketch/hll.h
@@ -521,7 +521,12 @@ inline void inc_counts(T &counts, const SIMDHolder *p, const SIMDHolder *pend) {
 static inline std::array<uint32_t, 64> sum_counts(const SIMDHolder *p, const SIMDHolder *pend) {
     // Should add Contiguous Container requirement.
     std::array<uint32_t, 64> counts{0};
-    inc_counts(counts, p, pend);
+    if((uint8_t *)pend - (uint8_t *)p < sizeof(*p)) {
+        const size_t e = (uint8_t *)pend - (uint8_t *)p;
+        for(size_t i = 0; i < e; ++i) ++counts[((uint8_t *)p)[i]];
+    } else {
+        inc_counts(counts, p, pend);
+    }
     return counts;
 }
 

--- a/include/sketch/hll.h
+++ b/include/sketch/hll.h
@@ -833,7 +833,7 @@ public:
 
     INLINE void add(uint64_t hashval) noexcept {
         const uint32_t index(q() == 64 ? uint32_t(0): uint32_t(hashval >> q()));
-        const uint32_t lzt = clz(((hashval << 1)|1) << (np_ - 1)) + 1;
+        const uint8_t lzt = clz(((hashval << 1)|1) << (np_ - 1)) + 1;
 #ifndef NOT_THREADSAFE
         for(;core_[index] < lzt;
              __sync_bool_compare_and_swap(&core_[index], core_[index], lzt));

--- a/include/sketch/hmh.h
+++ b/include/sketch/hmh.h
@@ -204,7 +204,7 @@ public:
 #ifndef NDEBUG
             bool pass = true;
             for(size_t i = 0; i < sizeof(lhv) / sizeof(IT); ++i) {
-                IT _lh = ((IT *)&lhv)[i], 
+                IT _lh = ((IT *)&lhv)[i],
                    _rh = ((IT *)&rhv)[i],
                    _mh = ((IT *)&maxv)[i];
                 if(_mh != std::max(_lh, _rh)) {
@@ -323,8 +323,8 @@ public:
             auto ptr = reinterpret_cast<const SIMDHolder *>(data_.data());
             auto eptr = reinterpret_cast<const SIMDHolder *>(&data_[data_.size()]);
             while(eptr - ptr > 8) {
-                update_point(ptr[0]); update_point(ptr[1]); update_point(ptr[2]); update_point(ptr[3]); 
-                update_point(ptr[4]); update_point(ptr[5]); update_point(ptr[6]); update_point(ptr[7]); 
+                update_point(ptr[0]); update_point(ptr[1]); update_point(ptr[2]); update_point(ptr[3]);
+                update_point(ptr[4]); update_point(ptr[5]); update_point(ptr[6]); update_point(ptr[7]);
                 ptr += 8;
             }
             while(ptr < eptr) update_point(*ptr++);
@@ -573,7 +573,7 @@ public:
 #    define __CMPEQ64(x, y) _mm_cmpeq_epi64(x, y)
 #  else
 #    define __CMPEQ64(x, y) _mm_and_si128(_mm_cmpeq_epi32(x, y), _mm_cmpeq_epi32(_mm_srli_epi64(x, 32), _mm_srli_epi64(y, 32)))
-#  endif 
+#  endif
 #  define __SETZERO() _mm_set1_epi32(0)
 #  define TYPE __m128i
 #endif
@@ -618,7 +618,7 @@ public:
 
 #endif // #if __AVX512BW__ else sse/avx
         } // if avx2 or 512 or sse2
-#endif 
+#endif
         return (uint64_t(cc) << 32) | nc;
     }
 #undef TYPE
@@ -679,7 +679,7 @@ struct HyperMinHasher: public hmh_t {
 
     mutable double card_ = UNSET_CARD;
     Hasher hf_;
-    
+
 
     template<typename...Args>
     HyperMinHasher(Args &&...args): hmh_t(std::forward<Args>(args)...) {}

--- a/include/sketch/integral.h
+++ b/include/sketch/integral.h
@@ -36,7 +36,7 @@ namespace sketch {
 inline namespace integral {
 #if defined(__GNUC__) || defined(__clang__)
 CUDA_ONLY(__host__ __device__) INLINE HOST_ONLY(constexpr) unsigned clz(signed long long x) noexcept {
-    return 
+    return
 #ifdef __CUDA_ARCH__
     __clzll(x);
 #else
@@ -287,7 +287,6 @@ template<>
 INLINE uint64_t sum_of_u64s<__m256i>(const __m256i val) noexcept {
     return *(const uint64_t *)&val + ((const uint64_t *)&val)[1] +
             ((const uint64_t *)&val)[2] + ((const uint64_t *)&val)[3];
-
 }
 #endif
 #if __SSE2__

--- a/include/sketch/integral.h
+++ b/include/sketch/integral.h
@@ -284,9 +284,11 @@ INLINE uint64_t sum_of_u64s(const T val) noexcept {
 
 #if __AVX2__
 template<>
-INLINE uint64_t sum_of_u64s<__m256i>(const __m256i val) noexcept {
-    return *(const uint64_t *)&val + ((const uint64_t *)&val)[1] +
-            ((const uint64_t *)&val)[2] + ((const uint64_t *)&val)[3];
+INLINE uint64_t sum_of_u64s<__m256i>(const __m256i x) noexcept {
+    __m256i y = (__m256i)(_mm256_permute2f128_pd((__m256d)x, (__m256d)x, 1));
+    __m256i m1 = _mm256_add_epi64(x, y);
+    __m256i m2 = (__m256i)_mm256_permute_pd((__m256d)m1, 5);
+    return _mm256_extract_epi64(_mm256_add_epi64(m1, m2), 0);
 }
 #endif
 #if __SSE2__

--- a/include/sketch/integral.h
+++ b/include/sketch/integral.h
@@ -294,7 +294,7 @@ INLINE uint64_t sum_of_u64s<__m256i>(const __m256i x) noexcept {
 #if __SSE2__
 template<>
 INLINE uint64_t sum_of_u64s<__m128i>(const __m128i val) noexcept {
-    return *(const uint64_t *)&val + ((const uint64_t *)&val)[1];
+    return _mm_extract_epi64(val, 0) + _mm_extract_epi64(val, 1);
 }
 #endif
 

--- a/include/sketch/median.h
+++ b/include/sketch/median.h
@@ -67,7 +67,7 @@ INLINE T median(T *v, size_t n) {
     }
     if(n < 50)
         detail::insertion_sort(v, v + n);
-    else 
+    else
 #ifdef PDQSORT_H
         pdqsort(v, v + n);
 #else

--- a/include/sketch/mod.h
+++ b/include/sketch/mod.h
@@ -90,7 +90,7 @@ public:
         size_t isz = this->intersection_size(o);
         return double(isz) / (this->first.size() + o.size() - isz);
     }
-    double containment_index(const FinalModHash &o) const {                                        
+    double containment_index(const FinalModHash &o) const {
         return double(this->intersection_size(o)) / this->first.size();
     }
     double cardinality_estimate() const {

--- a/include/sketch/pc.h
+++ b/include/sketch/pc.h
@@ -106,7 +106,7 @@ public:
             return n_ * 1.292808 * sum * sum;
 #endif
         }
-        double mean = 
+        double mean =
             double(std::accumulate(counters_.get(), counters_.get() + n_, 0u, [](auto x, auto y) {
                 return detail::r(y) + x;
             })) / n_;

--- a/include/sketch/setsketch.h
+++ b/include/sketch/setsketch.h
@@ -255,6 +255,9 @@ struct ByteSetS: public SetSketch<uint8_t, long double> {
 struct ShortSetS: public SetSketch<uint16_t, long double> {
     ShortSetS(int nreg, long double b=1.001, long double a=.25): SetSketch<uint16_t, long double>(nreg, b, a, 65534u) {}
 };
+struct WideShortSetS: public SetSketch<uint16_t, long double> {
+    WideShortSetS(int nreg, long double b=1.00095, long double a=.03): SetSketch<uint16_t, long double>(nreg, b, a, 65534u) {}
+};
 
 
 } // namespace sketch

--- a/include/sketch/setsketch.h
+++ b/include/sketch/setsketch.h
@@ -258,6 +258,9 @@ struct ShortSetS: public SetSketch<uint16_t, long double> {
 struct WideShortSetS: public SetSketch<uint16_t, long double> {
     WideShortSetS(int nreg, long double b=1.00095, long double a=.03): SetSketch<uint16_t, long double>(nreg, b, a, 65534u) {}
 };
+struct EShortSetS: public SetSketch<uint16_t, long double> {
+    EShortSetS(int nreg, long double b=1.0006, long double a=.001): SetSketch<uint16_t, long double>(nreg, b, a, 65534u) {}
+};
 
 
 } // namespace sketch

--- a/include/sketch/setsketch.h
+++ b/include/sketch/setsketch.h
@@ -1,0 +1,132 @@
+#ifndef EHLL_H__
+#define EHLL_H__
+#include <stdexcept>
+#include <cassert>
+#include "aesctr/wy.h"
+#include <queue>
+#include <div.h>
+#include <unordered_map>
+#include <memory>
+#include "fy.h"
+
+#ifndef NDEBUG
+#include <unordered_set>
+#endif
+
+// Implementations of set sketch
+
+template<typename ResT>
+struct LowKHelper {
+    const ResT *vals_;
+    uint64_t natval_, nvals_;
+    int klow_ = 0;
+    void assign(const ResT *vals, size_t nvals) {
+        vals_ = vals; nvals_ = nvals;
+        reset();
+    }
+    int klow() const {return klow_;}
+    void reset() {
+        klow_ =  *std::min_element(vals_, vals_ + nvals_);
+        size_t i;
+        for(i = natval_ = 0; i < nvals_; ++i) natval_ += (vals_[i] == klow_);
+    }
+    void remove(int kval) {
+        if(kval == klow_) {
+            if(--natval_ == 0) reset();
+        }
+    }
+};
+
+template<typename ResT, typename FT=double>
+struct SetSketch {
+private:
+    static_assert(std::is_floating_point<FT>::value, "Must float");
+    static_assert(std::is_integral<ResT>::value, "Must be integral");
+    // Set sketch 1
+    size_t m_; // Number of registers
+    const FT a_; // Exponential parameter
+    const FT b_; // Base
+    const FT ainv_;
+    const FT logbinv_;
+    int q_;
+    std::unique_ptr<ResT[]> data_;
+    fy::LazyShuffler ls_;
+    LowKHelper<ResT> lowkh_;
+    static ResT *allocate(size_t n) {
+        ResT *ret = nullptr;
+        if(posix_memalign((void **)&ret, 64, n * sizeof(ResT))) throw std::bad_alloc();
+        return ret;
+    }
+    FT getbeta(size_t idx) const {
+        return FT(1.) / (m_ - idx);
+    }
+public:
+    const ResT *data() const {return data_.get();}
+    SetSketch(size_t m, FT b, FT a, int q): m_(m), a_(a), b_(b), ainv_(1./ a), logbinv_(1. / std::log1p(b_ - 1.)), q_(q), ls_(m_) {
+        ResT *p = allocate(m_);
+        data_.reset(p);
+        std::fprintf(stderr, "base %g, a = %g\n", b, a);
+        std::fill(p, p + m_, static_cast<ResT>(0));
+        lowkh_.assign(p, m_);
+    }
+    size_t size() const {return m_;}
+    double b() const {return b_;}
+    double a() const {return a_;}
+    ResT &operator[](size_t i) {return data_[i];}
+    const ResT &operator[](size_t i) const {return data_[i];}
+    int klow() const {return lowkh_.klow();}
+    void update(uint64_t id) {
+        assert(lowkh_.nvals_ == m_);
+        auto mys = std::accumulate(lowkh_.vals_, lowkh_.vals_ + m_, size_t(0), [&](size_t ret, auto x) {return ret + (x == lowkh_.klow());});
+        assert(lowkh_.natval_ == mys);
+        assert(lowkh_.natval_ == std::accumulate(lowkh_.vals_, lowkh_.vals_ + m_, size_t(0), [&](size_t ret, auto x) {return ret + (x == lowkh_.klow());}));
+        size_t bi = 0;
+        uint64_t rv = wy::wyhash64_stateless(&id);
+        double ev = 0.;
+        ls_.reset();
+        ls_.seed(rv);
+#ifndef NDEBUG
+        std::unordered_set<uint64_t> idxs;
+#endif
+        for(;;) {
+            static constexpr double mul = 1. / (1ull << 52);
+            auto randv = -getbeta(bi) * ainv_ * std::log((rv >> 12) * mul);
+            ev += randv;
+            if(ev > std::pow(b_, -klow())) return;
+            const int k = std::max(0, std::min(q_ + 1, static_cast<int>((1. - std::log(ev) * logbinv_))));
+            //if(b_ >= 2.) std::fprintf(stderr, "ev: %g. k: %u. klow: %u\n", ev, k, klow());
+            if(k <= klow()) return;
+            auto idx = ls_.step();
+#ifndef NDEBUG
+            assert(idxs.find(idx) == idxs.end()); idxs.emplace(idx);
+#endif
+            if(k > data_[idx]) {
+                auto oldv = data_[idx];
+                data_[idx] = k;
+                lowkh_.remove(oldv);
+                assert(lowkh_.natval_ == std::accumulate(data_.get(), data_.get() + m_, size_t(0), [&](size_t ret, auto x) {return ret + (x == lowkh_.klow());}));
+            }
+            if(++bi == m_) {
+                assert(lowkh_.natval_ == std::accumulate(data_.get(), data_.get() + m_, size_t(0), [&](size_t ret, auto x) {return ret + (x == lowkh_.klow());}));
+                std::fprintf(stderr, "[%g] bi: %zu = m. Current klow: %u with %zu. Current %g. ev limit: %g\n", b_, bi, klow(), size_t(lowkh_.natval_), ev, std::pow(b_, -klow()));
+                return;
+            }
+            assert(bi == idxs.size());
+            //std::fprintf(stderr, "Current klow: %u, with %zu at\n", klow(), lowkh_.natval_);
+            assert(lowkh_.natval_ == std::accumulate(data_.get(), data_.get() + m_, size_t(0), [&](size_t ret, auto x) {return ret + (x == lowkh_.klow());}));
+            rv = wy::wyhash64_stateless(&id);
+        }
+    }
+};
+
+struct NibbleSetS: public SetSketch<uint8_t> {
+    NibbleSetS(int nreg): SetSketch<uint8_t>(nreg, 4., 1., 14) {}
+};
+struct ByteSetS: public SetSketch<uint8_t> {
+    ByteSetS(int nreg): SetSketch<uint8_t>(nreg, 1.2, 20., 254) {}
+};
+struct ShortSetS: public SetSketch<uint16_t> {
+    ShortSetS(int nreg): SetSketch<uint16_t>(nreg, 1.001, 30., 65534) {}
+};
+
+#endif

--- a/include/sketch/setsketch.h
+++ b/include/sketch/setsketch.h
@@ -40,6 +40,9 @@ struct LowKHelper {
     }
 };
 
+static inline long double g_b(long double b, long double arg) {
+    return (1 - std::pow(b, -arg)) / (1. - 1. / b);
+}
 template<typename ResT, typename FT=double>
 struct SetSketch {
 private:
@@ -160,6 +163,17 @@ public:
     size_t shared_registers(const SetSketch<ResT, FT> &o) const {
         return eq::count_eq(data(), o.data(), m_);
     }
+    std::pair<double, double> alpha_beta(const SetSketch<ResT, FT> &o) const {
+        auto gtlt = count_gtlt(data(), o.data(), m_);
+        return {g_b(b_, double(gtlt.first) / m_), g_b(b_, double(gtlt.second) / m_)};
+    }
+    static constexpr double __union_card(double alph, double beta, double lhcard, double rhcard) {
+        return std::max((lhcard + rhcard) / (2. - alph - beta), 0.);
+    }
+    std::tuple<double, double, double> alpha_beta_mu(const SetSketch<ResT, FT> &o, double mycard, double ocard) const {
+        auto ab = alpha_beta(o);
+        return {ab.first, ab.second, ___union_card(ab.first, ab.second, mycard, ocard)};
+    }
 };
 
 struct NibbleSetS: public SetSketch<uint8_t> {
@@ -174,6 +188,7 @@ struct ByteSetS: public SetSketch<uint8_t> {
 struct ShortSetS: public SetSketch<uint16_t> {
     ShortSetS(int nreg): SetSketch<uint16_t>(nreg, 1.001, 30., 65534) {}
 };
+
 
 } // namespace sketch
 

--- a/include/sketch/setsketch.h
+++ b/include/sketch/setsketch.h
@@ -476,9 +476,9 @@ class SetSketch {
     std::unique_ptr<ResT[]> data_;
     std::vector<uint64_t> ids_; // The IDs representing the sampled items.
                                 // Only used if SetSketch is
-    std::vector<FT> lbetas_; // Cache Beta values * 1. / a
     fy::LazyShuffler ls_;
     minvt_t<ResT> lowkh_;
+    std::vector<FT> lbetas_; // Cache Beta values * 1. / a
     static ResT *allocate(size_t n) {
         n = (n << 1) - 1;
         ResT *ret = nullptr;
@@ -491,9 +491,9 @@ class SetSketch {
             16;
 #endif
 #if __cplusplus >= 201703L && defined(_GLIBCXX_HAVE_ALIGNED_ALLOC)
-        if((ret = static_cast<FT *>(std::aligned_alloc(ALN, n * sizeof(FT)))) == nullptr)
+        if((ret = static_cast<ResT *>(std::aligned_alloc(ALN, n * sizeof(ResT)))) == nullptr)
 #else
-        if(posix_memalign((void **)&ret, ALN, n * sizeof(FT)))
+        if(posix_memalign((void **)&ret, ALN, n * sizeof(ResT)))
 #endif
             throw std::bad_alloc();
         return ret;
@@ -721,12 +721,14 @@ struct WideShortSetS: public SetSketch<uint16_t, long double> {
     template<typename...Args> WideShortSetS(Args &&...args): SetSketch<uint16_t, long double>(std::forward<Args>(args)...) {}
 };
 struct EShortSetS: public SetSketch<uint16_t, long double> {
+    using Super = SetSketch<uint16_t, long double>;
     static constexpr long double DEFAULT_B = 1.0006;
     static constexpr long double DEFAULT_A = .001;
     static constexpr size_t QV = 65534u;
     template<typename IT, typename OFT, typename=typename std::enable_if<std::is_integral<IT>::value && std::is_floating_point<OFT>::value>::type>
-    EShortSetS(IT nreg, OFT b=DEFAULT_B, OFT a=DEFAULT_A): SetSketch<uint16_t, long double>(nreg, b, a, QV) {}
-    template<typename...Args> EShortSetS(Args &&...args): SetSketch<uint16_t, long double>(std::forward<Args>(args)...) {}
+    EShortSetS(IT nreg, OFT b=DEFAULT_B, OFT a=DEFAULT_A): Super(nreg, b, a, QV) {}
+    EShortSetS(size_t nreg): Super(nreg, DEFAULT_B, DEFAULT_A, QV) {}
+    template<typename...Args> EShortSetS(Args &&...args): Super(std::forward<Args>(args)...) {}
 };
 struct EByteSetS: public SetSketch<uint8_t, double> {
     static constexpr double DEFAULT_B = 1.09;

--- a/include/sketch/setsketch.h
+++ b/include/sketch/setsketch.h
@@ -166,15 +166,19 @@ public:
         return eq::count_eq(data(), o.data(), m_);
     }
     std::pair<double, double> alpha_beta(const SetSketch<ResT, FT> &o) const {
-        auto gtlt = count_gtlt(data(), o.data(), m_);
-        return {g_b(b_, double(gtlt.first) / m_), g_b(b_, double(gtlt.second) / m_)};
+        auto gtlt = eq::count_gtlt(data(), o.data(), m_);
+        double alpha = g_b(b_, double(gtlt.first) / m_);
+        double beta = g_b(b_, double(gtlt.second) / m_);
+        return {alpha, beta};
     }
     static constexpr double __union_card(double alph, double beta, double lhcard, double rhcard) {
         return std::max((lhcard + rhcard) / (2. - alph - beta), 0.);
     }
     std::tuple<double, double, double> alpha_beta_mu(const SetSketch<ResT, FT> &o, double mycard, double ocard) const {
-        auto ab = alpha_beta(o);
-        return {ab.first, ab.second, ___union_card(ab.first, ab.second, mycard, ocard)};
+        const auto ab = alpha_beta(o);
+        if(ab.first + ab.second >= 1.) // They seem to be disjoint sets, use SetSketch (15)
+            return {(mycard) / (mycard + ocard), ocard / (mycard + ocard), mycard + ocard};
+        return {ab.first, ab.second, __union_card(ab.first, ab.second, mycard, ocard)};
     }
 };
 
@@ -188,7 +192,7 @@ struct ByteSetS: public SetSketch<uint8_t> {
     ByteSetS(int nreg): SetSketch<uint8_t>(nreg, 1.2, 20., 254) {}
 };
 struct ShortSetS: public SetSketch<uint16_t> {
-    ShortSetS(int nreg): SetSketch<uint16_t>(nreg, 1.001, 1., 65534 / 4) {}
+    ShortSetS(int nreg): SetSketch<uint16_t>(nreg, 1.001, 1., 65534) {}
 };
 
 

--- a/include/sketch/setsketch.h
+++ b/include/sketch/setsketch.h
@@ -163,10 +163,10 @@ public:
 };
 
 struct NibbleSetS: public SetSketch<uint8_t> {
-    NibbleSetS(int nreg): SetSketch<uint8_t>(nreg, 4., 1e-3, 14) {}
+    NibbleSetS(int nreg): SetSketch<uint8_t>(nreg, 16., 1., 14) {}
 };
 struct SmallNibbleSetS: public SetSketch<uint8_t> {
-    SmallNibbleSetS(int nreg): SetSketch<uint8_t>(nreg, 4., 1., 14) {}
+    SmallNibbleSetS(int nreg): SetSketch<uint8_t>(nreg, 4., 1e-6, 14) {}
 };
 struct ByteSetS: public SetSketch<uint8_t> {
     ByteSetS(int nreg): SetSketch<uint8_t>(nreg, 1.2, 20., 254) {}

--- a/include/sketch/setsketch.h
+++ b/include/sketch/setsketch.h
@@ -253,7 +253,7 @@ struct ByteSetS: public SetSketch<uint8_t, long double> {
     ByteSetS(int nreg, long double b=1.2, long double a=20.): Super(nreg, b, a, 254) {}
 };
 struct ShortSetS: public SetSketch<uint16_t, long double> {
-    ShortSetS(int nreg, long double b=1.001, long double a=1.): SetSketch<uint16_t, long double>(nreg, b, a, 65534) {}
+    ShortSetS(int nreg, long double b=1.001, long double a=.25): SetSketch<uint16_t, long double>(nreg, b, a, 65534u) {}
 };
 
 

--- a/include/sketch/setsketch.h
+++ b/include/sketch/setsketch.h
@@ -310,7 +310,12 @@ class CSetSketch {
 #else
             16;
 #endif
-        if(posix_memalign((void **)&ret, ALN, n * sizeof(FT))) throw std::bad_alloc();
+#if __cplusplus >= 201703L && defined(_GLIBCXX_HAVE_ALIGNED_ALLOC)
+        if((ret = static_cast<FT *>(std::aligned_alloc(ALN, n * sizeof(FT)))) == nullptr)
+#else
+        if(posix_memalign((void **)&ret, ALN, n * sizeof(FT)))
+#endif
+            throw std::bad_alloc();
         return ret;
     }
     FT getbeta(size_t idx) const {
@@ -485,7 +490,12 @@ class SetSketch {
 #else
             16;
 #endif
-        if(posix_memalign((void **)&ret, ALN, n * sizeof(ResT))) throw std::bad_alloc();
+#if __cplusplus >= 201703L && defined(_GLIBCXX_HAVE_ALIGNED_ALLOC)
+        if((ret = static_cast<FT *>(std::aligned_alloc(ALN, n * sizeof(FT)))) == nullptr)
+#else
+        if(posix_memalign((void **)&ret, ALN, n * sizeof(FT)))
+#endif
+            throw std::bad_alloc();
         return ret;
     }
     FT getbeta(size_t idx) const {

--- a/include/sketch/setsketch.h
+++ b/include/sketch/setsketch.h
@@ -163,8 +163,13 @@ public:
         std::unordered_set<uint64_t> idxs;
 #endif
         for(;;) {
-            static constexpr double mul = 1. / (1ull << 52);
-            ev += -getbeta(bi) * ainv_ * std::log((rv >> 12) * mul);
+            static constexpr double mul = 
+#if __cplusplus >= 201703L
+                0x1p-64;
+#else
+                5.421010862427522e-20;
+#endif
+            ev += -getbeta(bi) * ainv_ * std::log(rv * mul);
             if(ev > lowkh_.explim()) return;
             const int k = std::max(0, std::min(q_ + 1, static_cast<int>((1. - std::log(ev) * logbinv_))));
             if(k <= klow()) return;

--- a/include/sketch/setsketch.h
+++ b/include/sketch/setsketch.h
@@ -4,7 +4,7 @@
 #include <cassert>
 #include "aesctr/wy.h"
 #include <queue>
-#include <div.h>
+#include "sketch/div.h"
 #include <unordered_map>
 #include <memory>
 #include "fy.h"

--- a/include/sketch/setsketch.h
+++ b/include/sketch/setsketch.h
@@ -173,7 +173,7 @@ static inline long double g_b(long double b, long double arg) {
 
 template<typename FT>
 inline double calc_card(const FT *start, const FT *end) {
-    bool is_aligned = (reinterpret_cast<uint64_t>(start) % 
+    bool is_aligned = (reinterpret_cast<uint64_t>(start) %
 #if __AVX512F__
         64
 #elif __AVX2__
@@ -335,6 +335,8 @@ public:
     CSetSketch(const std::string &s): ls_(1), mvt_(1) {
         read(s);
     }
+    FT min() const {return *std::min_element(data(), data() + m_);}
+    FT max() const {return mvt_.max();}
     size_t size() const {return m_;}
     FT &operator[](size_t i) {return data_[i];}
     const FT &operator[](size_t i) const {return data_[i];}
@@ -442,6 +444,15 @@ public:
     const std::vector<uint64_t> &ids() const {return ids_;}
     double cardinality() const {
         return calc_card(data_.get(), &data_[m_]);
+    }
+    static std::pair<FT, FT> optimal_parameters(FT maxreg, FT minreg, size_t q) {
+        FT b = std::exp(std::log(minreg / maxreg) / q);
+        return {b, minreg / b};
+    }
+    template<typename ResT=uint16_t>
+    static std::pair<FT, FT> optimal_parameters(FT maxreg, FT minreg) {
+        static constexpr unsigned long long q = sizeof(ResT) = 1 ? 254ull : sizeof(ResT) == 2 ? 65534ull: sizeof(ResT) == 4 ? 4294967294ull: 18446744073709551614ull;
+        return optimal_parameters(maxreg, minreg, q);
     }
 };
 

--- a/include/sketch/sketch.h
+++ b/include/sketch/sketch.h
@@ -16,7 +16,7 @@
 #include "./vac.h"
 #include "./hbb.h"
 #include "./mod.h"
-#include "./rnla.h"
+#include "./setsketch.h"
 
 #ifdef __CUDACC__
 #include "hllgpu.h"

--- a/include/sketch/sseutil.h
+++ b/include/sketch/sseutil.h
@@ -4,6 +4,8 @@
 #include <cstdint>
 #include <cstddef>
 #include <cassert>
+#include <utility>
+#include <stdexcept>
 
 namespace sse {
 
@@ -35,6 +37,14 @@ enum class Alignment : size_t
     AVX512 = 64
 };
 
+
+#ifndef USE_ALIGNED_ALLOC
+#  if (__cplusplus >= 201703L && defined(_GLIBCXX_HAVE_ALIGNED_ALLOC))
+#    define USE_ALIGNED_ALLOC 1
+#  else
+#    define USE_ALIGNED_ALLOC 0
+#  endif
+#endif
 
 namespace detail {
     static inline void* allocate_aligned_memory(size_t align, size_t size) {

--- a/python/pysketch.h
+++ b/python/pysketch.h
@@ -145,5 +145,15 @@ py::array setsketch2np(const SetSketch<ResT, FT> &o) {
     }
     return ret;
 }
+template<typename FT>
+py::array setsketch2np(const CSetSketch<FT> &o) {
+    static constexpr size_t itemsize = sizeof(FT);
+    const char fc = itemsize == 4 ? 'f': itemsize == 8 ? 'd': itemsize ? 'g': 'e'; // g = longdouble, e = float16
+    std::string s(1, fc);
+    py::array ret(py::dtype(s), std::vector<py::ssize_t>({py::ssize_t(o.size())}));
+    auto ri = ret.request();
+    std::copy(o.data(), o.data() + o.size(), (FT *)ri.ptr);
+    return ret;
+}
 
 #endif

--- a/python/pysketch.h
+++ b/python/pysketch.h
@@ -7,6 +7,7 @@
 #include "sketch/hmh.h"
 #include <omp.h>
 #include "aesctr/wy.h"
+#include "sketch/setsketch.h"
 namespace py = pybind11;
 using namespace sketch;
 using namespace hll;
@@ -130,5 +131,19 @@ struct CSF {
         return x.containment_index(y);
     }
 };
+
+template<typename ResT, typename FT>
+py::array setsketch2np(const SetSketch<ResT, FT> &o) {
+    std::string s(1, sizeof(ResT) == 2 ? 'S': 'B');
+    py::array ret(py::dtype(s), std::vector<py::ssize_t>({py::ssize_t(o.size())}));
+    auto ri = ret.request();
+    if(sizeof(ResT) == 2) {
+        std::copy(o.data(), o.data() + o.size(), (uint16_t *)ri.ptr);
+    } else {
+        if(sizeof(ResT) != 1) throw std::runtime_error("Expected SetSketch with 2 bytes or 1 byte per register");
+        std::copy(o.data(), o.data() + o.size(), (uint8_t *)ri.ptr);
+    }
+    return ret;
+}
 
 #endif

--- a/python/setup.py
+++ b/python/setup.py
@@ -20,7 +20,6 @@ class get_pybind_include(object):
         import pybind11
         return pybind11.get_include(self.user)
 
-
 extra_compile_args = ['-march=native',
                       '-Wno-char-subscripts', '-Wno-unused-function',
                       '-Wno-strict-aliasing', '-Wno-ignored-attributes', '-fno-wrapv',

--- a/python/setup.py
+++ b/python/setup.py
@@ -23,7 +23,8 @@ class get_pybind_include(object):
 extra_compile_args = ['-march=native',
                       '-Wno-char-subscripts', '-Wno-unused-function',
                       '-Wno-strict-aliasing', '-Wno-ignored-attributes', '-fno-wrapv',
-                      '-lz', '-fopenmp', '-lgomp', '-DNDEBUG']
+                      '-lz', '-fopenmp', '-lgomp', '-DNDEBUG',
+                      '-DBLAZE_SHARED_MEMORY_PARALLELIZATION=0']
 
 include_dirs=[
     # Path to pybind11 headers
@@ -33,6 +34,7 @@ include_dirs=[
    "../libpopcnt",
    "../include",
    "../vec",
+   "../vec/blaze",
    "..",
    "../pybind11/include"
 ]
@@ -52,7 +54,7 @@ def make_module(namecppf):
         extra_compile_args=extra_compile_args
     )
 
-ext_modules = list(map(make_module, map(make_namepair, ('hll', 'bbmh', 'util', 'bf', 'hmh'))))
+ext_modules = list(map(make_module, map(make_namepair, ('hll', 'bbmh', 'util', 'bf', 'hmh', 'ss'))))
 
 '''
 ext_modules = [

--- a/python/ss.cpp
+++ b/python/ss.cpp
@@ -1,0 +1,99 @@
+#include "python/pysketch.h"
+#include "sketch/setsketch.h"
+
+PYBIND11_MODULE(sketch_hll, m) {
+    m.doc() = "SetSketch python bindings"; // optional module docstring
+    py::class_<EShortSetS> (m, "ShortSetSketch")
+        .def(py::init<size_t>())
+        .def(py::init<std::string>())
+        .def("clear", &EShortSetS::clear, "Clear all entries.")
+        .def("report", &EShortSetS::harmean, "Emit estimated cardinality.")
+        .def("add", [](EShortSetS &h1, uint64_t v) {h1.add(v);}, "Add a (hashed) value to the sketch.")
+        .def("addh", [](EShortSetS &h1, py::object p) {
+            auto hv = py::hash(p);
+            h1.addh(hv);
+        }, "Hash a python object and add it to the sketch.")
+        .def("jaccard_index", [](EShortSetS &h1, EShortSetS &h2) {
+            auto lhc = h1.harmean(), rhc = h2.harmean();
+            auto triple = h1.alpha_beta_mu(h2, lhc, rhc);
+            return std::max(0., (1. - std::get<0>(triple) - std::get<1>(triple)));
+        })
+        .def("union", [](const EShortSetS &h1, const EShortSetS &h2) {return h1 + h2;})
+        //.def("union_size", [](const EShortSetS &h1, const EShortSetS &h2) {return h1.union_size(h2);})
+        .def("__ior__", [](EShortSetS &lh, const EShortSetS &rh) {lh += rh; return lh;})
+        .def("__or__", [](const EShortSetS &lh, const EShortSetS &rh) {return lh + rh;})
+        .def("__eq__", [](const sketch::EShortSetS &h, const sketch::EShortSetS &h2) {
+            return h == h2;
+        }).def("__neq__", [](const sketch::EShortSetS &h, const sketch::EShortSetS &h2) {
+            return !(h == h2);
+        }).def("write", [](const sketch::EShortSetS &h, std::string path) {
+            h.write(path);
+        }).def("to_numpy", [](const sketch::EShortSetS &h) {
+            return setsketch2np(h);
+        });
+    m.def("jaccard_index", [](EShortSetS &h1, EShortSetS &h2) {
+            auto triple = h1.alpha_beta_mu(h2, h1.harmean(), h2.harmean());
+            return std::max(0., (1. - std::get<0>(triple) - std::get<1>(triple)));
+        }, "Calculates jaccard indexes between two sketches")
+    .def("from_np", [](const py::array_t<uint32_t> &input, size_t ss=10, long double b=1.0006, long double a=.001) {
+         EShortSetS ret(ss);
+         auto ptr = input.data();
+         for(ssize_t i = 0; i < input.size();ret.add(ptr[i++]));
+         return ret;
+    }, py::arg("array"), py::arg("sketchsize") = 10, py::arg("b") = 1.0006, py::arg("a") = .001,
+        py::return_value_policy::take_ownership, "Creates a SetSketch with 16-bit registers from a numpy array of 32-bit hashes.")
+    .def("from_np", [](const py::array_t<uint64_t> &input, size_t ss=10, long double b=1.0006, long double a=.001) {
+         EShortSetS ret(ss);
+         auto ptr = input.data();
+         for(ssize_t i = 0; i < input.size();ret.add(ptr[i++]));
+         return ret;
+     }, py::arg("array"), py::arg("sketchsize") = 10, py::arg("b") = 1.0006, py::arg("a") = .001,
+        py::return_value_policy::take_ownership, "Creates a SetSketch with 16-bit registers from a numpy array of (unhashed) 64-bit integers");
+    py::class_<EByteSetS> (m, "ByteSetSketch")
+        .def(py::init<size_t>())
+        .def(py::init<std::string>())
+        .def("clear", &EByteSetS::clear, "Clear all entries.")
+        .def("report", &EByteSetS::harmean, "Emit estimated cardinality.")
+        .def("add", [](EByteSetS &h1, uint64_t v) {h1.add(v);}, "Add a (hashed) value to the sketch.")
+        .def("addh", [](EByteSetS &h1, py::object p) {
+            auto hv = py::hash(p);
+            h1.addh(hv);
+        }, "Hash a python object and add it to the sketch.")
+        .def("jaccard_index", [](EByteSetS &h1, EByteSetS &h2) {
+            auto lhc = h1.harmean(), rhc = h2.harmean();
+            auto triple = h1.alpha_beta_mu(h2, lhc, rhc);
+            return std::max(0., (1. - std::get<0>(triple) - std::get<1>(triple)));
+        })
+        .def("union", [](const EByteSetS &h1, const EByteSetS &h2) {return h1 + h2;})
+        //.def("union_size", [](const EByteSetS &h1, const EByteSetS &h2) {return h1.union_size(h2);})
+        .def("__ior__", [](EByteSetS &lh, const EByteSetS &rh) {lh += rh; return lh;})
+        .def("__or__", [](const EByteSetS &lh, const EByteSetS &rh) {return lh + rh;})
+        .def("__eq__", [](const sketch::EByteSetS &h, const sketch::EByteSetS &h2) {
+            return h == h2;
+        }).def("__neq__", [](const sketch::EByteSetS &h, const sketch::EByteSetS &h2) {
+            return !(h == h2);
+        }).def("write", [](const sketch::EByteSetS &h, std::string path) {
+            h.write(path);
+        });
+    m.def("jaccard_index", [](EByteSetS &h1, EByteSetS &h2) {
+            auto triple = h1.alpha_beta_mu(h2, h1.harmean(), h2.harmean());
+            return std::max(0., (1. - std::get<0>(triple) - std::get<1>(triple)));
+        }, "Calculates jaccard indexes between two sketches")
+    .def("from_np", [](const py::array_t<uint32_t> &input, size_t ss=10, long double b=1.09, long double a=.08) {
+         EByteSetS ret(ss);
+         auto ptr = input.data();
+         for(ssize_t i = 0; i < input.size();ret.add(ptr[i++]));
+         return ret;
+    }, py::arg("array"), py::arg("sketchsize") = 10, py::arg("b") = 1.09, py::arg("a") = .08,
+        py::return_value_policy::take_ownership, "Creates a SetSketch with 8-bit registers from a numpy array of 32-bit hashes.")
+    .def("from_np", [](const py::array_t<uint64_t> &input, size_t ss=10, long double b=1.09, long double a=.08) {
+         EByteSetS ret(ss);
+         auto ptr = input.data();
+         for(ssize_t i = 0; i < input.size();ret.add(ptr[i++]));
+         return ret;
+     }, py::arg("array"), py::arg("sketchsize") = 10, py::arg("b") = 1.09, py::arg("a") = .08,
+        py::return_value_policy::take_ownership, "Creates a SetSketch with 8-bit registers from a numpy array of (unhashed) 64-bit integers")
+     .def("to_numpy", [](const sketch::EByteSetS &h) {
+            return setsketch2np(h);
+     });
+} // pybind11 module

--- a/python/ss.cpp
+++ b/python/ss.cpp
@@ -96,4 +96,48 @@ PYBIND11_MODULE(sketch_hll, m) {
      .def("to_numpy", [](const sketch::EByteSetS &h) {
             return setsketch2np(h);
      });
+    py::class_<CSetSketch<double>> (m, "CSetSketch")
+        .def(py::init<size_t>())
+        .def(py::init<std::string>())
+        .def("clear", &CSetSketch<double>::clear, "Clear all entries.")
+        .def("report", &CSetSketch<double>::cardinality, "Emit estimated cardinality.")
+        .def("add", [](CSetSketch<double> &h1, uint64_t v) {h1.add(v);}, "Add a (hashed) value to the sketch.")
+        .def("addh", [](CSetSketch<double> &h1, py::object p) {
+            auto hv = py::hash(p);
+            h1.addh(hv);
+        }, "Hash a python object and add it to the sketch.")
+        .def("jaccard_index", [](CSetSketch<double> &h1, CSetSketch<double> &h2) {
+            return h1.jaccard_index(h2);
+        })
+        .def("union", [](const CSetSketch<double> &h1, const CSetSketch<double> &h2) {return h1 + h2;})
+        //.def("union_size", [](const CSetSketch<double> &h1, const CSetSketch<double> &h2) {return h1.union_size(h2);})
+        .def("__ior__", [](CSetSketch<double> &lh, const CSetSketch<double> &rh) {lh += rh; return lh;})
+        .def("__or__", [](const CSetSketch<double> &lh, const CSetSketch<double> &rh) {return lh + rh;})
+        .def("__eq__", [](const sketch::CSetSketch<double> &h, const sketch::CSetSketch<double> &h2) {
+            return h == h2;
+        }).def("__neq__", [](const sketch::CSetSketch<double> &h, const sketch::CSetSketch<double> &h2) {
+            return !(h == h2);
+        }).def("write", [](const sketch::CSetSketch<double> &h, std::string path) {
+            h.write(path);
+        }).def("to_numpy", [](const sketch::CSetSketch<double> &h) {
+            return setsketch2np(h);
+        });
+    m.def("jaccard_index", [](EShortSetS &h1, EShortSetS &h2) {
+            auto triple = h1.alpha_beta_mu(h2, h1.harmean(), h2.harmean());
+            return std::max(0., (1. - std::get<0>(triple) - std::get<1>(triple)));
+        }, "Calculates jaccard indexes between two sketches")
+    .def("from_np", [](const py::array_t<uint32_t> &input, size_t ss=10, long double b=1.0006, long double a=.001) {
+         EShortSetS ret(ss);
+         auto ptr = input.data();
+         for(ssize_t i = 0; i < input.size();ret.add(ptr[i++]));
+         return ret;
+    }, py::arg("array"), py::arg("sketchsize") = 10, py::arg("b") = 1.0006, py::arg("a") = .001,
+        py::return_value_policy::take_ownership, "Creates a SetSketch with 16-bit registers from a numpy array of 32-bit hashes.")
+    .def("from_np", [](const py::array_t<uint64_t> &input, size_t ss=10, long double b=1.0006, long double a=.001) {
+         EShortSetS ret(ss);
+         auto ptr = input.data();
+         for(ssize_t i = 0; i < input.size();ret.add(ptr[i++]));
+         return ret;
+     }, py::arg("array"), py::arg("sketchsize") = 10, py::arg("b") = 1.0006, py::arg("a") = .001,
+        py::return_value_policy::take_ownership, "Creates a SetSketch with 16-bit registers from a numpy array of (unhashed) 64-bit integers");
 } // pybind11 module

--- a/python/util.cpp
+++ b/python/util.cpp
@@ -148,7 +148,7 @@ PYBIND11_MODULE(sketch_util, m) {
     m.def("ij2ind", [](size_t i, size_t j, size_t n) {return i < j ? (((i) * (n * 2 - i - 1)) / 2 + j - (i + 1)): (((j) * (n * 2 - j - 1)) / 2 + i - (j + 1));});
     m.def("randset", [](size_t i) {
         thread_local wy::WyHash<uint64_t, 4> gen(1337 + std::hash<std::thread::id>()(std::this_thread::get_id()));
-        py::array_t<uint64_t> ret({i});
+        py::array_t<uint64_t> ret({py::ssize_t(i)});
         auto ptr = static_cast<uint64_t *>(ret.request().ptr);
         OMP_PFOR
         for(size_t j = 0; j < i; ++j) {

--- a/python/util.cpp
+++ b/python/util.cpp
@@ -80,7 +80,7 @@ PYBIND11_MODULE(sketch_util, m) {
         py::buffer_info lhinfo = lhs.request(), rhinfo = rhs.request();
         if(lhinfo.format != rhinfo.format) throw std::runtime_error("dtypes for lhs and rhs array are not the same");
         if(lhinfo.ndim != rhinfo.ndim || lhinfo.ndim != 1) throw std::runtime_error("Wrong number of dimensions");
-        
+
         size_t ret;
 #define PERF_ISZ__(type) \
         if(py::isinstance<py::array_t<type>>(lhs)) { \

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e 
+set -e
 set -o pipefail
 
 make setup_tests -j8

--- a/testsrc/count.cpp
+++ b/testsrc/count.cpp
@@ -1,12 +1,18 @@
 #include "sketch/count_eq.h"
+#include <iostream>
 
 template<typename T>
 int do_main() {
     std::vector<T> rhs(100), lhs(100);
     std::iota(rhs.begin(), rhs.end(), 0u);
-    std::iota(lhs.begin(), lhs.end(), 0u);
+    lhs = rhs;
+    std::fprintf(stderr, "%s\n", __PRETTY_FUNCTION__);
     lhs[17] = 1;
+    assert(rhs[17] > lhs[17]);
     auto nm = sketch::eq::count_eq(lhs.data(), rhs.data(), 100);
+    auto gtlt = sketch::eq::count_gtlt(lhs.data(), rhs.data(), 100);
+    assert(gtlt.first == 0);
+    assert(gtlt.second == 1);
     std::fprintf(stderr, "nmatched: %zu\n", nm);
     if(sizeof(T) == 1) {
         std::memset(&rhs[0], 0, 100);

--- a/testsrc/count.cpp
+++ b/testsrc/count.cpp
@@ -15,6 +15,27 @@ int do_main() {
         std::fprintf(stderr, "nm: %zu\n", nm);
         assert(nm == 200);
     }
+    double tt = 0., t2 = 0.;
+    const size_t n = 1000000;
+    wy::WyRand<uint64_t> rng(13);
+    rhs.resize(n);
+    lhs.resize(n);
+    for(auto &i: rhs) i = rng();
+    for(auto &i: lhs) i = rng();
+    size_t nm2 = 0, nmb = 0;
+    constexpr size_t NPER = sizeof(T) / sizeof(char);
+    for(size_t i = 0; i < 1; ++i) {
+        auto t = std::chrono::high_resolution_clock::now();
+        nm2 += sketch::eq::count_eq_nibbles((const uint8_t *)lhs.data(), (const uint8_t *)rhs.data(), rhs.size() * NPER * 2);
+        auto e = std::chrono::high_resolution_clock::now();
+        tt += std::chrono::duration<double, std::milli>(e - t).count();
+        t = std::chrono::high_resolution_clock::now();
+        nmb += sketch::eq::count_eq_bytes((const uint8_t *)lhs.data(), (const uint8_t *)rhs.data(), rhs.size() * NPER);
+        e = std::chrono::high_resolution_clock::now();
+        t2 += std::chrono::duration<double, std::milli>(e - t).count();
+    }
+    std::fprintf(stderr, "%gms per %zu nibbles, %zu (%%%g) match\n", tt, rhs.size() * NPER * 2, nm2, double(nm2) / n / NPER / 2 * 100.);
+    std::fprintf(stderr, "%gms per %zu bytes, %zu (%%%g) match\n", t2, rhs.size() * NPER, nmb, double(nmb) / n / NPER * 100.);
     return nm != 99;
 }
 

--- a/testsrc/count.cpp
+++ b/testsrc/count.cpp
@@ -3,17 +3,24 @@
 
 template<typename T>
 int do_main() {
-    std::vector<T> rhs(100), lhs(100);
+    std::vector<T, sketch::Allocator<T>> rhs(100, 0), lhs(100, 0);
     std::iota(rhs.begin(), rhs.end(), 0u);
     lhs = rhs;
     std::fprintf(stderr, "%s\n", __PRETTY_FUNCTION__);
     lhs[17] = 1;
     assert(rhs[17] > lhs[17]);
     auto nm = sketch::eq::count_eq(lhs.data(), rhs.data(), 100);
-    auto gtlt = sketch::eq::count_gtlt(lhs.data(), rhs.data(), 100);
+    auto gtlti = sketch::eq::count_gtlt(lhs.data(), rhs.data(), 100);
+    std::pair<size_t, size_t> gtlt = {gtlti.first, gtlti.second};
     assert(gtlt.first == 0);
     assert(gtlt.second == 1);
     std::fprintf(stderr, "nmatched: %zu\n", nm);
+    for(size_t i = 0; i < 100; ++i) lhs[i] = rhs[i] + 1;
+    gtlti = sketch::eq::count_gtlt(lhs.data(), rhs.data(), 100);
+    gtlt = {gtlti.first, gtlti.second};
+    std::fprintf(stderr, "[%s] gtlt %zu/%zu\n", __PRETTY_FUNCTION__, gtlt.first, gtlt.second);
+    assert(gtlt.first == 100);
+    lhs = rhs;
     if(sizeof(T) == 1) {
         std::memset(&rhs[0], 0, 100);
         std::memset(&lhs[0], 0, 100);

--- a/testsrc/cscomp.cpp
+++ b/testsrc/cscomp.cpp
@@ -15,7 +15,7 @@ int main() {
     auto step1_2 = cs_compress(init, 13, hf);
     auto step2 = cs_decompress(step1, D, hf);
     auto step2_1 = cs_decompress(step1_1, D, hf);
-    // top_indices_from_compressed(const C &in, size_t newdim, size_t olddim, const KWiseHasherSet<4> &hf, unsigned k) 
+    // top_indices_from_compressed(const C &in, size_t newdim, size_t olddim, const KWiseHasherSet<4> &hf, unsigned k)
     auto topind = top_indices_from_compressed(step1, D, 100, hf, 20);
     std::fprintf(stderr, "topind sizes: %zu, %zu\n", topind.first.size(), topind.second.size());
     for(const auto i: topind.first) {
@@ -58,6 +58,6 @@ int main() {
     //assert((is3.pnorm() - sn) / sn * 100. <= 12.);
     auto us = is2.union_size(is3);
     std::fprintf(stderr, "us: %f. n1 %f, n2 %f. expected: %zu. %% diff: %f\n", us, is2.pnorm(), is3.pnorm(), sn * 19, fracdiff(us, is2.pnorm() + is3.pnorm()) * 100.);
-    //std::fprintf(stderr, "Expected us: %f\n", 
+    //std::fprintf(stderr, "Expected us: %f\n",
     auto diff = is2 - is3;
 }

--- a/testsrc/modtest.cpp
+++ b/testsrc/modtest.cpp
@@ -3,7 +3,7 @@
 
 using namespace sketch;
 int main() {
-    modsketch_t<hash::WangHash, uint64_t, 
+    modsketch_t<hash::WangHash, uint64_t,
                 policy::SizeDivPolicy<uint64_t>,
                 std::allocator<uint64_t>
                 > mod(16);

--- a/testsrc/serial_test.cpp
+++ b/testsrc/serial_test.cpp
@@ -1,5 +1,6 @@
 #include "hll.h"
 #include "bbmh.h"
+#include "sketch/setsketch.h"
 #include "aesctr/wy.h"
 #include <chrono>
 using namespace sketch;
@@ -82,5 +83,12 @@ int main(int argc, char *argv[]) {
         gzclose(fp);
         if(std::system("rm 10hlls.whooo")) throw "sideways";
         assert(std::equal(hlls.begin(), hlls.end(), ohlls.begin()));
+    }
+    {
+        EShortSetS ss(100);
+        for(size_t i = 0; i < 1000; ++i) ss.add(i);
+        ss.write("ss100.ss");
+        EShortSetS ss2("ss100.ss");
+        assert(ss2 == ss);
     }
 }

--- a/testsrc/serial_test.cpp
+++ b/testsrc/serial_test.cpp
@@ -90,5 +90,6 @@ int main(int argc, char *argv[]) {
         ss.write("ss100.ss");
         EShortSetS ss2("ss100.ss");
         assert(ss2 == ss);
+        if(std::system("rm ss100.ss")) throw "sideways";
     }
 }

--- a/testsrc/sstest.cpp
+++ b/testsrc/sstest.cpp
@@ -16,7 +16,7 @@ int main(int argc, char **argv) {
     NibbleSetS shl(m<<1), shr(m<<1);
     NibbleSet8 nshl(m<<1), nshr(m<<1);
     ShortSetS lhn(m, sb, sa), rhn(m, sb, sa);
-    hll_t h(ilog2(roundup(m)));
+    hll_t h(ilog2(roundup(m));
     auto t = std::chrono::high_resolution_clock::now();
     for(size_t i = 0; i < n; ++i) {
         h.addh(i);
@@ -51,7 +51,7 @@ int main(int argc, char **argv) {
         auto a = std::get<0>(abmu);
         auto b = std::get<1>(abmu);
         auto mu = std::get<2>(abmu);
-        auto isz = mu * (1. - a - b);
+        auto isz = std::max(0., mu * (1. - a - b));
         std::fprintf(stderr, "Alpha: %g. beta: %g. mu: %g. isz: %g. JI: %g\n", a, b, mu, isz, isz / mu);
     }
     std::fprintf(stderr, "Registers for nibbles: Max: %u. min: %u.\n", *std::max_element(shl.data(), shl.data() + m), *std::min_element(shl.data(), shl.data() + m));

--- a/testsrc/sstest.cpp
+++ b/testsrc/sstest.cpp
@@ -1,0 +1,61 @@
+#include "setsketch.h"
+#include "hll.h"
+#include <chrono>
+
+using namespace sketch;
+struct NibbleSet8: public SetSketch<uint8_t> {
+    NibbleSet8(int nreg): SetSketch<uint8_t>(nreg, 8., 1., 14) {}
+};
+int main(int argc, char **argv) {
+    const size_t n = argc <= 1 ? 1000: std::atoi(argv[1]);
+    const size_t m = argc <= 2 ? 25: std::atoi(argv[2]);
+    double sb = argc <= 3 ? 1.001: std::atof(argv[3]);
+    const double sa = argc <= 4 ? 30: std::atof(argv[4]);
+    double hlv, bc, nc, sc, n8c;
+    ByteSetS lhb(m), rhb(m);
+    NibbleSetS shl(m<<1), shr(m<<1);
+    NibbleSet8 nshl(m<<1), nshr(m<<1);
+    ShortSetS lhn(m, sb, sa), rhn(m, sb, sa);
+    hll_t h(ilog2(roundup(m)));
+    auto t = std::chrono::high_resolution_clock::now();
+    for(size_t i = 0; i < n; ++i) {
+        h.addh(i);
+        lhb.update(i);
+        rhb.update(i);
+        lhn.update(i); rhn.update(i);
+        shl.update(i); shr.update(i);
+        nshl.update(i); nshr.update(i);
+        lhn.update(i + 0xFFFFFFFFFFFull);
+        lhn.update(i + 0x1FFFFFFFFFFFull);
+        rhn.update(i + 0xFFFFFFFFFFFFFFull);
+        rhn.update(i + 0x1FFFFFFFFFFFFFFull);
+    }
+    auto t2 = std::chrono::high_resolution_clock::now();
+    std::fprintf(stderr, "Time for %zu : %0.20g\n", n, std::chrono::duration<double, std::milli>(t2 - t).count());
+    hlv = h.report();
+    bc = lhb.cardinality(), nc = shl.cardinality(), sc = rhn.cardinality(), n8c = nshl.cardinality();
+    std::fprintf(stderr, "h report: %0.20g, %%%f error\n", hlv, std::abs(hlv - n) / n * 100.);
+    assert(std::equal(lhb.data(), lhb.data() + lhb.size(), rhb.data()));
+    std::fprintf(stderr, "Cardinality for nibs: %0.20g, %%%f error\n", nc, std::abs(nc - n) / n * 100.);
+    std::fprintf(stderr, "Cardinality for nib8s: %0.20g, %%%f error\n", n8c, std::abs(n8c - n) / n * 100.);
+    std::fprintf(stderr, "Cardinality for bytes: %0.20g, %%%f error\n", bc, std::abs(bc - n) / n * 100.);
+    std::fprintf(stderr, "Cardinality for shorts: %0.20g, %%%f error\n", sc, std::abs(sc - 3 * n) / (3 * n) * 100.);
+    size_t mat = 0;
+    for(size_t i = 0; i < lhn.size(); ++i) {
+        mat += lhn[i] == rhn[i];
+    }
+    {
+        auto lhb =lhn.data(), lhe = lhb + lhn.size();
+        std::fprintf(stderr, "Matching registers for Short set: %zu/%zu. Max: %u. min: %u.\n", mat, lhn.size(), *std::max_element(lhb, lhe), *std::min_element(lhb, lhe));
+        auto abmu = lhn.alpha_beta_mu(rhn, lhn.cardinality(), rhn.cardinality());
+        auto a = std::get<0>(abmu);
+        auto b = std::get<1>(abmu);
+        auto mu = std::get<2>(abmu);
+        auto isz = mu * (1. - a - b);
+        std::fprintf(stderr, "Alpha: %g. beta: %g. mu: %g. isz: %g. JI: %g\n", a, b, mu, isz, isz / mu);
+    }
+    std::fprintf(stderr, "Registers for nibbles: Max: %u. min: %u.\n", *std::max_element(shl.data(), shl.data() + m), *std::min_element(shl.data(), shl.data() + m));
+    std::fprintf(stderr, "Registers for smallnibbles: Max: %u. min: %u.\n", *std::max_element(nshl.data(), nshl.data() + m), *std::min_element(nshl.data(), nshl.data() + m));
+    std::fprintf(stderr, "Registers for bytes: Max: %u. min: %u.\n", *std::max_element(lhb.data(), lhb.data() + m), *std::min_element(lhb.data(), lhb.data() + m));
+    std::fprintf(stderr, "Registers for shorts: Max: %u. min: %u.\n", *std::max_element(rhn.data(), rhn.data() + rhn.size()), *std::min_element(rhn.data(), rhn.data() + rhn.size()));
+}

--- a/testsrc/sstest.cpp
+++ b/testsrc/sstest.cpp
@@ -13,6 +13,7 @@ int main(int argc, char **argv) {
     const double sa = argc <= 4 ? 30: std::atof(argv[4]);
     double hlv, bc, nc, sc, n8c;
     ByteSetS lhb(m), rhb(m);
+    //ByteSetS lhb(m, sb, sa), rhb(m, sb, sa);
     NibbleSetS shl(m<<1), shr(m<<1);
     NibbleSet8 nshl(m<<1), nshr(m<<1);
     ShortSetS lhn(m, sb, sa), rhn(m, sb, sa);

--- a/testsrc/sstest.cpp
+++ b/testsrc/sstest.cpp
@@ -64,7 +64,7 @@ int main(int argc, char **argv) {
     }
     {
         auto lhb =lhn.data(), lhe = lhb + lhn.size();
-        std::fprintf(stderr, "Matching registers for Short set: %zu/%zu. Max: %u. min: %u.\n", mat, lhn.size(), *std::max_element(lhb, lhe), *std::min_element(lhb, lhe));
+        std::fprintf(stderr, "Matching registers for Short set: %zu/%zu. Max: %0.10Lg. min: %0.10Lg.\n", mat, lhn.size(), (long double)*std::max_element(lhb, lhe), (long double)*std::min_element(lhb, lhe));
         auto abmu = lhn.alpha_beta_mu(rhn, lhn.cardinality(), rhn.cardinality());
         auto a = std::get<0>(abmu);
         auto b = std::get<1>(abmu);
@@ -72,6 +72,7 @@ int main(int argc, char **argv) {
         auto isz = std::max(0., mu * (1. - a - b));
         std::fprintf(stderr, "Alpha: %g. beta: %g. mu: %g. isz: %g. JI: %g\n", a, b, mu, isz, isz / mu);
     }
+    std::fprintf(stderr, "CSetSketch min: %0.20Lg, max: %0.20Lg\n", (long double)css.min(), (long double)css.max());
     std::fprintf(stderr, "Registers for nibbles: Max: %u. min: %u.\n", *std::max_element(shl.data(), shl.data() + m), *std::min_element(shl.data(), shl.data() + m));
     std::fprintf(stderr, "Registers for smallnibbles: Max: %u. min: %u.\n", *std::max_element(nshl.data(), nshl.data() + m), *std::min_element(nshl.data(), nshl.data() + m));
     std::fprintf(stderr, "Registers for bytes: Max: %u. min: %u.\n", *std::max_element(lhb.data(), lhb.data() + m), *std::min_element(lhb.data(), lhb.data() + m));

--- a/testsrc/sstest.cpp
+++ b/testsrc/sstest.cpp
@@ -16,7 +16,7 @@ int main(int argc, char **argv) {
     NibbleSetS shl(m<<1), shr(m<<1);
     NibbleSet8 nshl(m<<1), nshr(m<<1);
     ShortSetS lhn(m, sb, sa), rhn(m, sb, sa);
-    hll_t h(ilog2(roundup(m));
+    hll_t h(ilog2(roundup(m)));
     auto t = std::chrono::high_resolution_clock::now();
     for(size_t i = 0; i < n; ++i) {
         h.addh(i);


### PR DESCRIPTION
CSetSketch + Parameterization
SetSketch and CSetSketch python bindings.


u64 summation improvements, and add kernels for counting > and < between integral arrays of 8 and 16 bit integers. (These are in `sketch/count_eq.h", which has `count_eq` and `count_gtlt` functions.